### PR TITLE
Fix money display fallback in Util::aboutMoney

### DIFF
--- a/trade/hako-util.php
+++ b/trade/hako-util.php
@@ -16,8 +16,8 @@ class Util {
   function aboutMoney($m,$t) {
     global $init;
     if($init->moneyMode) {
-	$max = $init->allmax[$t];
-	$perc = ceil($m/$max*100);
+        $max = $init->allmax[$t];
+        $perc = ceil($m/$max*100);
       if($perc < 5) {
         return '<IMG SRC="infoc1.png" align="left" title="皆無" ALT="皆無">';
       } elseif($perc < 20) {
@@ -30,7 +30,7 @@ class Util {
         return '<IMG SRC="infoc5.png" align="left" title="底無" ALT="底無">';
       }
     } else {
-      return $money . $init->unitMoney;
+      return $m . $init->unitMoney;
     }
   }
   //---------------------------------------------------


### PR DESCRIPTION
## Summary
- correct Util::aboutMoney to use the provided amount when moneyMode is disabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695429408bac83268c6cc24988390b42)