### PR TITLE
Rename legacy Error class to HakoError for PHP 8 compatibility

### DIFF
--- a/trade/hako-edit.php
+++ b/trade/hako-edit.php
@@ -605,7 +605,7 @@ END;
     // パスワード
     if(!Util::checkPassword("", $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 
@@ -705,7 +705,7 @@ END;
     // パスワード
     if(!Util::checkPassword("", $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 
@@ -872,7 +872,7 @@ END;
     // パスワード
     if(!Util::checkPassword("", $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 
@@ -928,7 +928,7 @@ class Main {
     $cgi->parseInputData();
     if(!$hako->readIslands($cgi)) {
       HTML::header($cgi->dataSet);
-      Error::noDataFile();
+      HakoError::noDataFile();
       HTML::footer();
       exit();
     }

--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -949,7 +949,7 @@ class HtmlMap extends HTML {
 
     // パスワードチェック
     if(!Util::checkPassword($island['password'], $data['PASSWORD'])){
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
     $this->tempOwer($hako, $data, $number);
@@ -2431,7 +2431,7 @@ END;
     $number = $hako->idToNumber[$id];
     // なぜかその国がない場合
     if($number < 0 || $number > $hako->islandNumber) {
-      Error::problem();
+      HakoError::problem();
       return;
     }
     $island = $hako->islands[$number];
@@ -3827,112 +3827,112 @@ class HtmlSetted extends HTML {
     print "{$init->tagBig_}コマンドを登録しました{$init->spanend}<hr>\n";
   }
 }
-class Error {
-  function wrongPassword() {
+class HakoError {
+  public static function wrongPassword() {
     global $init;
     print "{$init->tagBig_}パスワードが違います。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function wrongID() {
+  public static function wrongID() {
     global $init;
     print "{$init->tagBig_}IDが違います。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
   // hakojima.datがない
-  function noDataFile() {
+  public static function noDataFile() {
     global $init;
     print "{$init->tagBig_}データファイルが開けません。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function newIslandFull() {
+  public static function newIslandFull() {
     global $init;
     print "{$init->tagBig_}申し訳ありません、国が一杯で登録できません！！{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
   // 受付中かどうか
-  function tempNewIslandForbbiden() {
+  public static function tempNewIslandForbbiden() {
     global $init;
     print "{$init->tagBig_}申し訳ありません、受付を中止しています。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function newIslandNoName() {
+  public static function newIslandNoName() {
     global $init;
     print "{$init->tagBig_}国につける名前が必要です。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function newIslandBadName() {
+  public static function newIslandBadName() {
     global $init;
     print "{$init->tagBig_},?()<>\$とか入ってたり、「無人国」とかいった変な名前はやめましょうよ～。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function newIslandAlready() {
+  public static function newIslandAlready() {
     global $init;
     print "{$init->tagBig_}その国ならすでに発見されています。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function newIslandNoPassword() {
+  public static function newIslandNoPassword() {
     global $init;
     print "{$init->tagBig_}パスワードが必要です。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function newIslandNoAgree() {
+  public static function newIslandNoAgree() {
     global $init;
     print "{$init->tagBig_}規約に同意してください。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function changeNoMoney() {
+  public static function changeNoMoney() {
     global $init;
     print "{$init->tagBig_}資金不足のため変更できません{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function changeNothing() {
+  public static function changeNothing() {
     global $init;
     print "{$init->tagBig_}名前、パスワードともに空欄です{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function problem() {
+  public static function problem() {
     global $init;
     print "{$init->tagBig_}問題発生、とりあえず戻ってください。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function lbbsNoMessage() {
+  public static function lbbsNoMessage() {
     global $init;
     print "{$init->tagBig_}名前または内容の欄が空欄です。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function NewsNoText() {
+  public static function NewsNoText() {
     global $init;
     print "{$init->tagBig_}報道内容欄が空欄です。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function NewsNoPoint() {
+  public static function NewsNoPoint() {
     global $init;
     print "{$init->tagBig_}残り投稿回数が0のため記帳できません。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function lockFail() {
+  public static function lockFail() {
     global $init;
     print "{$init->tagBig_}同時アクセスエラーです。<BR>ブラウザの「戻る」ボタンを押し、<BR>しばらく待ってから再度お試し下さい。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }
-  function lbbsNoMoney() {
+  public static function lbbsNoMoney() {
     global $init;
     print "{$init->tagBig_}資金不足のため記帳できません。{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -1015,7 +1015,7 @@ class Main {
     $cgi->getCookies();
     if(!$hako->readIslands($cgi)) {
       HTML::header($cgi->dataSet);
-      Error::noDataFile();
+      HakoError::noDataFile();
       HTML::footer();
       exit();
     }

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -19,41 +19,41 @@ class Make {
     global $init;
     $log = new Log;
     if($hako->islandNumber >= $init->maxIsland) {
-      Error::newIslandFull();
+      HakoError::newIslandFull();
       return;
     }
 
     // 受付ターンかどうか
     if(($hako->islandTurn >= $init->entryTurn) && ($init->entryTurn > 0)) {
-        Error::tempNewIslandForbbiden();
+        HakoError::tempNewIslandForbbiden();
         return;
     }
 
     if(empty($data['ISLANDNAME'])) {
-      Error::newIslandNoName();
+      HakoError::newIslandNoName();
       return;
     }
     // 名前が正当化チェック
     if(preg_match('/[,?()<>$]/', $data['ISLANDNAME']) || strcmp($data['ISLANDNAME'], "無人") == 0) {
-      Error::newIslandBadName();
+      HakoError::newIslandBadName();
       return;
     }
     // 名前の重複チェック
     if(Util::nameToNumber($hako, $data['ISLANDNAME']) != -1) {
-      Error::newIslandAlready();
+      HakoError::newIslandAlready();
       return;
     }
     // パスワードの存在判定
     if(empty($data['PASSWORD'])) {
-      Error::newIslandNoPassword();
+      HakoError::newIslandNoPassword();
       return;
     }
     if(strcmp($data['PASSWORD'], $data['PASSWORD2']) != 0) {
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 	if($data['agree'] != "agree"){
-      Error::newIslandNoAgree();
+      HakoError::newIslandNoAgree();
       return;
 	}
     // 新しい島の番号を決める
@@ -252,7 +252,7 @@ class Make {
     // パスワード
     if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
     // メッセージを更新
@@ -290,19 +290,19 @@ class Make {
     // パスワード
     if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
     
     if (empty($data['TEXT'])) {
       //空白
-      Error::NewsNoText();
+      HakoError::NewsNoText();
       return;   
     }
 
 	if ($island['news_point'] == 0) {
       //残り投稿回数0
-      Error::NewsNoPoint();
+      HakoError::NewsNoPoint();
       return;	
 	}
 
@@ -358,7 +358,7 @@ class Make {
     // パスワード
     if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
     switch($type) {
@@ -425,14 +425,14 @@ class Make {
 
     // なぜかその島がない場合
     if($num != 0 && empty($num)) {
-      Error::problem();
+      HakoError::problem();
       return;
     }
 
     // 削除モードじゃなくて名前かメッセージがない場合
     if(empty($data['DEL']) && empty($data['CHK'])) {
       if(empty($data['LBBSNAME']) || (empty($data['LBBSMESSAGE']))) {
-        Error::lbbsNoMessage();
+        HakoError::lbbsNoMessage();
         return;
       }
     }
@@ -441,7 +441,7 @@ class Make {
     if($data['lbbsMode'] == 1) {
       if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
         // password間違い
-        Error::wrongPassword();
+        HakoError::wrongPassword();
         return;
       }
 
@@ -458,14 +458,14 @@ class Make {
 
         // なぜかその島がない場合
         if($sNum != 0 && empty($sNum)) {
-          Error::problem();
+          HakoError::problem();
           return;
         }
 
         // パスワードチェック
         if(!Util::checkPassword($sIsland['password'], $data['PASSWORD'])) {
           // password間違い
-          Error::wrongPassword();
+          HakoError::wrongPassword();
           return;
         }
 
@@ -480,7 +480,7 @@ class Make {
         }
         if($sIsland['money'] < $cost) {
           // 費用不足
-          Error::lbbsNoMoney();
+          HakoError::lbbsNoMoney();
           return;
         }
         $sIsland['money'] -= $cost;
@@ -513,14 +513,14 @@ class Make {
 
       // なぜかその島がない場合
       if($sNum != 0 && empty($sNum)) {
-        Error::problem();
+        HakoError::problem();
         return;
       }
 
       // パスワードチェック
       if(!Util::checkPassword($sIsland['password'], $data['PASSWORD'])) {
         // password間違い
-        Error::wrongPassword();
+        HakoError::wrongPassword();
         return;
       }
     }
@@ -542,7 +542,7 @@ class Make {
         list($sName, $sId) = mb_split(",", $sTemp);
         if($sId != $data['ISLANDID2']) {
           // ID間違い
-          Error::wrongID();
+          HakoError::wrongID();
           return;
         }
       }
@@ -601,13 +601,13 @@ class Make {
 
     // なぜかその国がない場合
     if($num != 0 && empty($num)) {
-      Error::problem();
+      HakoError::problem();
       return;
     }
     //パスワードチェック
       if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
         // password間違い
-        Error::wrongPassword();
+        HakoError::wrongPassword();
         return;
     }
 
@@ -618,7 +618,7 @@ class Make {
       // 削除モード
       list($t,$k,$a,$start) = explode(",",$regT[$data['NUMBER']]);
 	  if(($hako->islandTurn < $start + $init->regTTerm)&&($hako->islandTurn !== $start)){
-	  Error::problem();
+	  HakoError::problem();
 	  }else{
       // 輸送予定を前にずらす
       Util::slideregT($regT, $data['NUMBER']);
@@ -627,7 +627,7 @@ class Make {
     } else {
       // 記帳モード
 	  if($id == $target){
-	  Error::problem();
+	  HakoError::problem();
 		  }else{
 		    for($i = 0; $i < $init->regTMax; $i++) {
 				if(!empty($regT[$i])){
@@ -635,7 +635,7 @@ class Make {
 				}
 			}
 		  if(($nu == $init->regTsMax && $island['bport'] == 0)||($nu == $init->regTMax && $island['bport'] == 1)){
-			  Error::problem();
+			  HakoError::problem();
 		  }else{
 			  if($kind == 72){
 			  //食糧輸送のみ輸送量を10分の1にする
@@ -681,14 +681,14 @@ class Make {
       //$island['food']  = $init->maxFood;
     } elseif(!Util::checkPassword($island['password'], $data['OLDPASS'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 
     // 確認用パスワード
     if(strcmp($data['PASSWORD'], $data['PASSWORD2']) != 0) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 
@@ -696,19 +696,19 @@ class Make {
       // 名前変更の場合
       // 名前が正当かチェック
       if(preg_match('/[,?()<>$]/', $data['ISLANDNAME']) || strcmp($data['ISLANDNAME'], "無人") == 0) {
-        Error::newIslandBadName();
+        HakoError::newIslandBadName();
         return;
       }
 
       // 名前の重複チェック
       if(Util::nameToNumber($hako, $data['ISLANDNAME']) != -1) {
-        Error::newIslandAlready();
+        HakoError::newIslandAlready();
         return;
       }
 
       if($island['money'] < $init->costChangeName) {
         // 金が足りない
-        Error::changeNoMoney();
+        HakoError::changeNoMoney();
         return;
       }
 
@@ -731,7 +731,7 @@ class Make {
 
     if(($flag == 0) && (strcmp($data['PASSWORD'], $data['PASSWORD2']) != 0)) {
       // どちらも変更されていない
-      Error::changeNothing();
+      HakoError::changeNothing();
       return;
     }
     $hako->islands[$num] = $island;
@@ -758,7 +758,7 @@ class Make {
    //   $island['food']  = $init->maxFood;
     } elseif(!Util::checkPassword($island['password'], $data['OLDPASS'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
     $island['owner'] = htmlspecialchars($data['OWNERNAME']);
@@ -783,7 +783,7 @@ class Make {
     if(strcmp($data['PASSWORD'], $init->specialPassword) == 0) {
     } elseif(!Util::checkPassword($island['password'], $data['OLDPASS'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 	if ($island['freeze'] == 1) {
@@ -811,7 +811,7 @@ class Make {
     // パスワード
     if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
 
@@ -899,7 +899,7 @@ class MakeJS extends Make {
     // パスワード
     if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
       // password間違い
-      Error::wrongPassword();
+      HakoError::wrongPassword();
       return;
     }
     // モードで分岐

--- a/trade/hako-util.php
+++ b/trade/hako-util.php
@@ -585,7 +585,7 @@ class Util {
     set_file_buffer($fp, 0);
     if(!flock($fp, LOCK_EX)) {
       fclose($fp);
-      Error::lockFail();
+      HakoError::lockFail();
     }
     rewind($fp);
   }
@@ -596,7 +596,7 @@ class Util {
     set_file_buffer($fp, 0);
     if(!flock($fp, LOCK_SH)) {
       fclose($fp);
-      Error::lockFail();
+      HakoError::lockFail();
     }
     rewind($fp);
   }


### PR DESCRIPTION
### Motivation
- The project defined a global `class Error` which conflicts with PHP's built-in `Error` class on PHP 7+ and causes the runtime error `Cannot declare class Error, because the name is already in use` under PHP 8.  

### Description
- Rename the legacy `Error` class to `HakoError` and update all static invocations from `Error::...()` to `HakoError::...()` across the codebase.  
- Convert the error-handler methods to `public static` so they match the existing static call pattern.  
- Changes applied to `trade/hako-html.php`, `trade/hako-main.php`, `trade/hako-turn.php`, `trade/hako-util.php`, and `trade/hako-edit.php` to replace usages and the class definition.

### Testing
- Ran syntax checks on the modified files with `for f in trade/hako-html.php trade/hako-main.php trade/hako-turn.php trade/hako-util.php trade/hako-edit.php; do php -l "$f" || exit 1; done` and all listed files returned `No syntax errors detected`.  
- Verified replacement of `Error::` and `class Error` with `HakoError::` / `class HakoError` using ripgrep (`rg`) to ensure no remaining reference in the modified files.  
- Note: a full repository `php -l` run via `find trade -name '*.php' -print0 | xargs -0 -n1 php -l` still fails due to an unrelated existing parse error in `trade/img/up/sam.php` (unclosed brace), which is outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c652fdf248326a0544c6357a4a285)