### PR TITLE
Replace removed each() calls with foreach in trade PHP scripts

### DIFF
--- a/trade/hako-axes.php
+++ b/trade/hako-axes.php
@@ -80,7 +80,7 @@ class Main {
   function parseInputData() {
     $this->mode = $_POST['mode'];    
     if(!empty($_POST)) {
-      while(list($name, $value) = each($_POST)) {
+      foreach($_POST as $name => $value) {
 //        $value = Util::sjis_convert($value);
         // 半角カナがあれば全角に変換して返す
 //        $value = i18n_ja_jp_hantozen($value,"KHV");

--- a/trade/hako-edit.php
+++ b/trade/hako-edit.php
@@ -559,7 +559,7 @@ class Cgi {
 
     $this->mode = $_POST['mode'];
     if(!empty($_POST)) {
-      while(list($name, $value) = each($_POST)) {
+      foreach($_POST as $name => $value) {
         $value = str_replace(",", "", $value);
         $value = JcodeConvert($value, 0, 2);
         $value = HANtoZEN_SJIS($value);

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -802,7 +802,7 @@ class Cgi {
   //---------------------------------------------------
 	function getCookies() {
     if(!empty($_COOKIE)) {
-      while(list($name, $value) = each($_COOKIE)) {
+      foreach($_COOKIE as $name => $value) {
         switch($name) {
         case "OWNISLANDID":
           $this->dataSet['defaultID'] = $value;
@@ -901,7 +901,7 @@ class Cgi {
 
     $this->mode = $_POST['mode'];
     if(!empty($_POST)) {
-      while(list($name, $value) = each($_POST)) {
+      foreach($_POST as $name => $value) {
         $value = str_replace(",", "", $value);
         $value = JcodeConvert($value, 0, 4);
         //$value = HANtoZEN($value,4);

--- a/trade/hako-mente-safemode.php
+++ b/trade/hako-mente-safemode.php
@@ -204,7 +204,7 @@ class Main {
   function parseInputData() {
     $this->mode = $_POST['mode'];    
     if(!empty($_POST)) {
-      while(list($name, $value) = each($_POST)) {
+      foreach($_POST as $name => $value) {
 //        $value = Util::sjis_convert($value);
         // 半角カナがあれば全角に変換して返す
 //        $value = i18n_ja_jp_hantozen($value,"KHV");

--- a/trade/hako-mente.php
+++ b/trade/hako-mente.php
@@ -197,7 +197,7 @@ class Main {
   function parseInputData() {
     $this->mode = $_POST['mode'];    
     if(!empty($_POST)) {
-      while(list($name, $value) = each($_POST)) {
+      foreach($_POST as $name => $value) {
 //        $value = Util::sjis_convert($value);
         // 半角カナがあれば全角に変換して返す
 //        $value = i18n_ja_jp_hantozen($value,"KHV");

--- a/trade/hako-present.php
+++ b/trade/hako-present.php
@@ -192,7 +192,7 @@ class Main {
   function parseInputData() {
     $this->mode = $_POST['mode'];    
     if(!empty($_POST)) {
-      while(list($name, $value) = each($_POST)) {
+      foreach($_POST as $name => $value) {
         // 半角カナがあれば全角に変換して返す
         JcodeConvert($value, 0, 2);
         $value = str_replace(",", "", $value);


### PR DESCRIPTION
### Motivation
- The codebase used the removed PHP function `each()`, which causes a fatal `Call to undefined function each()` under PHP 8 (observed at `trade/hako-main.php:805`).
- Update iteration over superglobals to a supported construct and remove latent identical issues in sibling scripts.

### Description
- Replaced `while(list($name, $value) = each($_COOKIE)) {` with `foreach($_COOKIE as $name => $value) {` in `trade/hako-main.php` to fix the reported fatal error while keeping cookie handling logic unchanged.
- Replaced `while(list($name, $value) = each($_POST)) {` with `foreach($_POST as $name => $value) {` in the files `trade/hako-main.php`, `trade/hako-present.php`, `trade/hako-mente-safemode.php`, `trade/hako-axes.php`, `trade/hako-edit.php`, and `trade/hako-mente.php` while preserving existing processing (e.g. `JcodeConvert`, `str_replace`, `stripslashes`).
- No other behavioral changes were made beyond converting deprecated iteration to `foreach`.

### Testing
- Confirmed no remaining `each()` usages with `rg -n '\beach\s*\(' trade/*.php` and verified the pattern no longer appears in the modified files.
- Verified PHP runtime with `php -v` (PHP 8.x reported in the test environment).
- Linted all modified files with `php -l` in a loop and the linter reported OK for each file.
- All automated checks executed in the environment succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c6846d1988326b761bcf1280dd3bc)