### PR TITLE
Init: fix $comTrain reference and add __construct() for compatibility

### DIFF
--- a/trade/config.php
+++ b/trade/config.php
@@ -1003,7 +1003,7 @@ class Init {
 	  'oil'=>$this->maxOil);
 
 	 $this->comGovernment = array(
-	  $init->comTrain => '1',
+	  $this->comTrain => '1',
       $this->comMissileNM=>'1',
 	  $this->comPubinvest=>'2',
 	  $this->comEduinvest=>'2',
@@ -1072,6 +1072,10 @@ class Init {
 		'bgCommandCell'=>$this->bgCommandCell
 	);
 
+  }
+
+  function __construct() {
+    $this->Init();
   }
 
   function Init() {


### PR DESCRIPTION
### Motivation
- Ensure the `Init` class initializes correctly and uses the proper instance property references to avoid undefined variable errors and improve compatibility with modern PHP constructors.

### Description
- Replace an incorrect `$init->comTrain` reference with the proper `$this->comTrain` inside the `$this->comGovernment` array to fix a variable scope/undefined reference issue.
- Add a PHP5-style `__construct()` that calls the existing `Init()` method so the class initializes reliably in environments that expect `__construct`.

### Testing
- Ran PHP linting with `php -l trade/config.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c69483db483268cbc6297e9dfd768)