### PR TITLE
Fix PHP warnings from 2026-06-02 log: initialize legacy properties, guards, and template update

### DIFF
--- a/trade/config.php
+++ b/trade/config.php
@@ -497,12 +497,14 @@ class Init {
   var $bgCommandCell = 'class="CommandCell"'; // 開発計画入力済み計画
 
   var $spanend = '</span>';
+  var $spanend2 = '</span>';
   var $tplcss;
   /********************
       地形番号
    ********************/
 
   var $landSea		=  0; // 海
+  var $landsea		=  0; // PHP 8 warning対策: landSeaの旧表記互換
   var $landWaste	=  1; // 荒地
   var $landPlains	=  2; // 平地
   var $landTown		=  3; // 町系
@@ -512,6 +514,9 @@ class Init {
   var $landOil		=  7; // 海底油田
   var $landFarm		=  8; // 農場
   var $landSfarm	=  9; // 海底農場→廃止予定
+  var $landSeaSide  =  9; // PHP 8 warning対策: 旧表記互換
+  var $landSsyoubou = 27; // PHP 8 warning対策: 旧表記互換
+  var $landlandSea  =  0; // PHP 8 warning対策: 旧表記互換
   var $landNursery  = 10; // 養殖場
   var $landMarket	= 11; // 市場
   var $landFactory	= 12; // 工場
@@ -664,6 +669,9 @@ class Init {
   var $comAutoDelete	= 93; // 全コマンド消去
 
   var $comName;
+  var $comPower = -1; // 廃止済みコマンドの互換値
+  var $comSfarm = -1; // 廃止済みコマンドの互換値
+  var $comExplosive = -1; // 廃止済みコマンドの互換値
   var $comCost;
   var $comSCost;
 
@@ -683,8 +691,16 @@ class Init {
   // コメントなどに、予\定のように\が勝手に追加される
   var $stripslashes;
 
+  var $allyUse = false;
+  var $unitMonster = "匹";
+  var $disTenki = 0;
+
   function setVariable() {
     $this->pointNumber = $this->islandSize * $this->islandSize;
+    $this->landsea = $this->landSea;
+    $this->landSeaSide = $this->landSfarm;
+    $this->landSsyoubou = $this->landSdefence;
+    $this->landlandSea = $this->landSea;
 
     $this->comList	= array(
       $this->comPrepare,

--- a/trade/hako-ally.php
+++ b/trade/hako-ally.php
@@ -5,10 +5,12 @@ hako-ally.php v0.1
 =================================================================*/
 
 //-----------------------------------------------------------------
-define("READ_LINE", 1024);
-$GAME_TOP = $init->baseDir . "/hako-main.php";
-$THIS_FILE = $init->baseDir . "/hako-ally.php";
-$BACK_TO_TOP = "<a href=\"{$GAME_TOP}?\">{$init->tagBig_}ゲームへ戻る{$init->_tagBig}</a>、<A HREF=\"{$THIS_FILE}?\">{$init->tagBig_}同盟トップへ戻る{$init->_tagBig}</A>";
+if(!defined("READ_LINE")) { define("READ_LINE", 1024); }
+if(isset($init) && is_object($init)) {
+  $GAME_TOP = $init->baseDir . "/hako-main.php";
+  $THIS_FILE = $init->baseDir . "/hako-ally.php";
+  $BACK_TO_TOP = "<a href=\"{$GAME_TOP}?\">{$init->tagBig_}ゲームへ戻る{$init->_tagBig}</a>、<A HREF=\"{$THIS_FILE}?\">{$init->tagBig_}同盟トップへ戻る{$init->_tagBig}</A>";
+}
 //-----------------------------------------------------------------
 
 //=================================================================

--- a/trade/hako-file.php
+++ b/trade/hako-file.php
@@ -105,6 +105,11 @@ class HakoIO {
     $news_link    = chop(fgets($fp, READ_LINE));
     
     $this->idToName[$id] = $name;
+    $land = array();
+    $landValue = array();
+    $command = array();
+    $lbbs = array();
+    $regT = array();
 
     if(($num == -1) || ($num == $id)) {
       $fp_i = fopen("{$init->dirName}/island.{$id}", "r");

--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -143,7 +143,9 @@ END;
 		$param = array_merge($param,$init->tplcss);
 		//テンプレートエンジン部分
 	    $html = file_get_contents($tpl);
-	    $html = preg_replace('/{(.+?)}/e', '$param[$1]', $html);
+	    $html = preg_replace_callback('/{(.+?)}/', function($matches) use ($param) {
+        return isset($param[$matches[1]]) ? $param[$matches[1]] : '';
+      }, $html);
 	    return $html;
 	}
 }
@@ -1373,6 +1375,7 @@ END;
     $land      = $island['land'];
     $landValue = $island['landValue'];
     $command   = $island['command'];
+    $comStr    = array();
 	$invest    = $island['invest'];
 	$Cname     = $island['Cname'];
 	$ctype	   = $island['capital'];
@@ -1398,10 +1401,12 @@ END;
       if($y % 2 == 0) { print "<img class=\"subchip\" src=\"land00.gif\" width=\"{$subsize}\" height=\"{$landsize}\" alt=\"{$y}\">"; }
 
       for($x = 0; $x < $init->islandSize; $x++) {
-	  	if($land[$x][$y] == $init->landFBase){
+		$target = '';
+		if($land[$x][$y] == $init->landFBase && isset($hako->idToName[$landValue[$x][$y]])){
 			$target = $hako->idToName[$landValue[$x][$y]];
 		}
-        $hako->landString($land[$x][$y], $landValue[$x][$y], $x, $y, $mode, $comStr[$x][$y], $invest, $Cname,$ctype,$target);
+        $commandText = isset($comStr[$x][$y]) ? $comStr[$x][$y] : '';
+        $hako->landString($land[$x][$y], $landValue[$x][$y], $x, $y, $mode, $commandText, $invest, $Cname,$ctype,$target);
       }
 
       if($y % 2 == 1) { print "<img name=\" class=\"subchip\" src=\"land00.gif\" width=\"{$subsize}\" height=\"{$landsize}\" alt=\"{$y}\">"; }

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -14,11 +14,11 @@ require 'hako-file.php';
 require 'hako-html.php';
 require 'hako-turn.php';
 require 'hako-util.php';
-require 'hako-ally.php';
 require 'wns.php';
 $init = new Init;
+require 'hako-ally.php';
 
-define("READ_LINE", 1024);
+if(!defined("READ_LINE")) { define("READ_LINE", 1024); }
 $THIS_FILE =  $init->baseDir . "/hako-main.php";
 $BACK_TO_TOP = "<A HREF=\"{$THIS_FILE}?\">{$init->tagBig_}トップへ戻る{$init->_tagBig}</A>";
 $_TURN; // ターン数
@@ -115,6 +115,7 @@ class Hako extends HakoIO {
     global $init;
     $point = "({$x},{$y})";
     $naviExp = "''";
+    $naviText = "";
 
     if($x < $init->islandSize / 2)
       $naviPos = 0;
@@ -848,47 +849,47 @@ class Cgi {
     $time = time() + 30 * 86400; // 現在 + 30日有効
 
     // Cookieの設定 & POSTで入力されたデータで、Cookieから取得したデータを更新
-    if($this->dataSet['ISLANDID'] && $this->mode == "owner") {
+    if(!empty($this->dataSet['ISLANDID']) && $this->mode == "owner") {
       setcookie("OWNISLANDID",$this->dataSet['ISLANDID'], $time);
       $this->dataSet['defaultID'] = $this->dataSet['ISLANDID'];
     }
-    if($this->dataSet['PASSWORD']) {
+    if(!empty($this->dataSet['PASSWORD'])) {
       setcookie("OWNISLANDPASSWORD",$this->dataSet['PASSWORD'], $time);
       $this->dataSet['defaultPassword'] = $this->dataSet['PASSWORD'];
     }
-    if($this->dataSet['TARGETID']) {
+    if(!empty($this->dataSet['TARGETID'])) {
       setcookie("TARGETISLANDID",$this->dataSet['TARGETID'], $time);
       $this->dataSet['defaultTarget'] = $this->dataSet['TARGETID'];
     }
-    if($this->dataSet['LBBSNAME']) {
+    if(!empty($this->dataSet['LBBSNAME'])) {
       setcookie("LBBSNAME",$this->dataSet['LBBSNAME'], $time);
       $this->dataSet['defaultName'] = $this->dataSet['LBBSNAME'];
     }
-    if($this->dataSet['LBBSCOLOR']) {
+    if(!empty($this->dataSet['LBBSCOLOR'])) {
       setcookie("LBBSCOLOR",$this->dataSet['LBBSCOLOR'], $time);
       $this->dataSet['defaultColor'] = $this->dataSet['LBBSCOLOR'];
     }
-    if($this->dataSet['POINTX']) {
+    if(!empty($this->dataSet['POINTX'])) {
       setcookie("POINTX",$this->dataSet['POINTX'], $time);
       $this->dataSet['defaultX'] = $this->dataSet['POINTX'];
     }
-    if($this->dataSet['POINTY']) {
+    if(!empty($this->dataSet['POINTY'])) {
       setcookie("POINTY",$this->dataSet['POINTY'], $time);
       $this->dataSet['defaultY'] = $this->dataSet['POINTY'];
     }
-    if($this->dataSet['COMMAND']) {
+    if(!empty($this->dataSet['COMMAND'])) {
       setcookie("COMMAND",$this->dataSet['COMMAND'], $time);
       $this->dataSet['defaultKind'] = $this->dataSet['COMMAND'];
     }
-    if($this->dataSet['DEVELOPEMODE']) {
+    if(!empty($this->dataSet['DEVELOPEMODE'])) {
       setcookie("DEVELOPEMODE",$this->dataSet['DEVELOPEMODE'], $time);
       $this->dataSet['defaultDevelopeMode'] = $this->dataSet['DEVELOPEMODE'];
     }
-    if($this->dataSet['SKIN']) {
+    if(!empty($this->dataSet['SKIN'])) {
       setcookie("SKIN",$this->dataSet['SKIN'], $time);
       $this->dataSet['defaultSkin'] = $this->dataSet['SKIN'];
     }
-    if($this->dataSet['IMG']) {
+    if(!empty($this->dataSet['IMG'])) {
       setcookie("IMG",$this->dataSet['IMG'], $time);
       $this->dataSet['defaultImg'] = $this->dataSet['IMG'];
     }
@@ -899,7 +900,35 @@ class Cgi {
   function parseInputData() {
     global $init;
 
-    $this->mode = $_POST['mode'];
+    $this->mode = isset($_POST['mode']) ? $_POST['mode'] : '';
+    $this->dataSet = array_merge(array(
+      'mode' => '',
+      'ISLANDID' => '',
+      'PASSWORD' => '',
+      'TARGETID' => '',
+      'LBBSNAME' => '',
+      'LBBSCOLOR' => '',
+      'POINTX' => '',
+      'POINTY' => '',
+      'COMMAND' => '',
+      'DEVELOPEMODE' => '',
+      'SKIN' => '',
+      'IMG' => '',
+      'ISLANDNAME' => '',
+      'MESSAGE' => '',
+      'LBBSMESSAGE' => '',
+      'defaultID' => 0,
+      'defaultTarget' => 0,
+      'defaultPassword' => '',
+      'defaultName' => '',
+      'defaultColor' => '',
+      'defaultX' => 0,
+      'defaultY' => 0,
+      'defaultKind' => 0,
+      'defaultDevelopeMode' => '',
+      'defaultSkin' => '',
+      'defaultImg' => ''
+    ), isset($this->dataSet) && is_array($this->dataSet) ? $this->dataSet : array());
     if(!empty($_POST)) {
       foreach($_POST as $name => $value) {
         $value = str_replace(",", "", $value);
@@ -932,31 +961,32 @@ class Cgi {
       $this->dataSet['ISLANDID'] = $_GET['target'];
     }
 	$this->dataSet['mobile'] = false;
-	$is_iphone = strpos( $_SERVER['HTTP_USER_AGENT'],'iPhone');
-	$is_android = strpos($_SERVER['HTTP_USER_AGENT'],'Android');
+	$userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
+	$is_iphone = strpos($userAgent, 'iPhone');
+	$is_android = strpos($userAgent, 'Android');
 	if(($is_iphone || $is_android) == true){
 		$this->dataSet['mobile'] = true;
 	}
 
-    if($_GET['mode'] == "conf") {
+    if(isset($_GET['mode']) && $_GET['mode'] == "conf") {
       $this->mode = "conf";
     }
-    if($_GET['mode'] == "New") {
+    if(isset($_GET['mode']) && $_GET['mode'] == "New") {
       $this->mode = "New";
     }
-    if($_GET['mode'] == "log") {
+    if(isset($_GET['mode']) && $_GET['mode'] == "log") {
       $this->mode = "log";
     }
-	if($_GET['mode'] == "wstat"){
+	if(isset($_GET['mode']) && $_GET['mode'] == "wstat"){
       $this->mode = "wstat";
 	}
-	if($_GET['mode'] == "nest"){
+	if(isset($_GET['mode']) && $_GET['mode'] == "nest"){
       $this->mode = "nest";
 	}
-	if($_GET['mode'] == "report"){
+	if(isset($_GET['mode']) && $_GET['mode'] == "report"){
 		$this->mode = "report";
 	}
-	if($_GET['mode'] == "ally"){
+	if(isset($_GET['mode']) && $_GET['mode'] == "ally"){
       $this->mode = "ally";
 	}
 

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -3841,7 +3841,7 @@ class Turn {
 	  	($x == 21)||
 	  	(($x == 0)&&($y % 2 == 1))){
 	  	$lv = 254;
-	  	$land[$x][$y] = $init->landsea;
+		$land[$x][$y] = $init->landSea;
 		$landValue[$x][$y] = $lv;
 	  }
 
@@ -3924,7 +3924,7 @@ class Turn {
         $landValue[$x][$y] = $lv;
         break;
 
-	  case $init->landsea:
+	  case $init->landSea:
 	  	//海異常修正
 	  	  if(($lv >= 6)&&($lv < 254)){
 		  	$lv = 0;
@@ -5887,7 +5887,7 @@ class Turn {
       // 燃料があるときだけ(負荷軽減)
       // 初期条件
       $bfarm = $bfactory = $bmarket = 100;
-      $wfarm = $wfactory = $wmarket = $pgoods = 0;
+      $wfarm = $wfactory = $wmarket = $pgoods = $pfactory = $sgoods = $smoney = 0;
 
       if ($pfarm + $factory + $market != 0) {
         // 特化判定
@@ -6218,7 +6218,11 @@ if($island['ffactory']> 0){
 	$cmente = 0;
 	$polit = 0;
 	$bport = 0;
-	$fsocst = $island['fsocst'];
+	$secpol = 0;
+	$m0 = 0;
+	$m11 = 0;
+	$kasan = 0;
+	$fsocst = isset($island['fsocst']) ? $island['fsocst'] : false;
     $passenger = $fishingboat = $tansaku = $senkan = $viking = 0;
     // 数える
     for($y = 0; $y < $init->islandSize; $y++) {
@@ -6559,7 +6563,7 @@ if($island['ffactory']> 0){
 		$hapiness += ceil($island['soclv']*0.2);
 	}
 	//減少は0.1ずつなので使うときは小数点切り上げ（ceil）を使う
-	$hapiness += $island['percat'];//食肉指数を幸福度に加算
+	$hapiness += isset($island['percat']) ? $island['percat'] : 0;//食肉指数を幸福度に加算
 	if ($m10 >= 1){
 		//宗教施設1つにつき幸福度＋3（最大12）
 		$hapiness += min($m10*3, 12);

--- a/trade/hako-util.php
+++ b/trade/hako-util.php
@@ -94,6 +94,7 @@ class Util {
   // 数字を見やすくする
   //---------------------------------------------------
   public static function Rewriter($amount){
+      $amounts = "";
       $amount = strrev($amount);
 	  $len = strlen($amount);
 	  $lens = floor($len/4);


### PR DESCRIPTION
### Motivation
- error_log の集計で多発していた PHP Warning（未定義プロパティ/変数、`/e` 修飾子の preg_replace、定数再定義 など）を抑止するための互換性と入力ガードを追加しました。 
- 古いコード（小文字の `landsea` 参照や廃止されたコマンド名等）が PHP8 環境で大量の警告を出していたため、既存ロジックを壊さずに警告を減らすことを目的としています。

### Description
- `Init` に互換用のプロパティとデフォルトを追加し、旧表記や廃止済みコマンド参照の警告を抑止するために `trade/config.php` に `landsea` / `landSeaSide` / `landlandSea` / `allyUse` / `unitMonster` / `comPower` などを追加し、`setVariable()` でエイリアスを設定しました.
- `hako-ally.php` のトップレベル初期化を `READ_LINE` 定義をガードしつつ `$init` 生成後に読み込むよう順序調整して `$init` 未定義・定数重複の警告を防止しました（`trade/hako-main.php` を変更）。
- `dataSet` の未定義参照を防ぐために `parseInputData()` で `dataSet` の初期値を一括設定し、`setCookies()` 側の条件を `empty()`/`!empty()` でチェックするように修正しました（`trade/hako-main.php`）。
- 地図レンダリングとテンプレート周りで未初期化になる変数（`$comStr` / `$target` / `$naviText`）を初期化し、`hako-file.php` 側で配列（`$land`/`$landValue`/`$command`/`$lbbs`/`$regT`）を読込前に初期化して未定義アクセスを回避しました。
- `preg_replace('/.../e', ...)` を `preg_replace_callback` に置換して PHP8 非互換な `/e` 修飾子の警告を解消しました（`trade/hako-html.php`）。
- ターン処理内の小文字 `landsea` 参照を正しい `landSea` に統一し、`income` / `estimate` 等で未初期化のカウンタやキー参照に対してデフォルトを設定して警告を減らしました（`trade/hako-turn.php`）。
- 数字整形関数で使われる `$amounts` 等の未初期化変数を初期化して `Undefined variable` を抑止しました（`trade/hako-util.php`）。

### Testing
- エラーログを解析するスクリプトで上位の警告発生箇所を特定して対応対象を決定しました（スクリプト実行は成功）。
- `git diff --check` を実行して差分チェックを行い問題点の指摘を解消しました（問題なし）。
- 各変更ファイルに対して `php -l` で構文チェックを実行し `trade/config.php` `trade/hako-ally.php` `trade/hako-util.php` `trade/hako-main.php` `trade/hako-html.php` `trade/hako-file.php` `trade/hako-turn.php` の構文エラーは検出されませんでした（すべて合格）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0e4ff4288326a6cb70633822bde0)