### PR TITLE
Fix PHP 8 warnings in turn processing (landKind casing, eisei casts, Miyage, slideBack)

### DIFF
--- a/trade/hako-log.php
+++ b/trade/hako-log.php
@@ -121,7 +121,7 @@ class Log extends LogIO {
   // お土産
   function Miyage($id, $name, $lName, $point, $str) {
     global $init;
-    $this->out("<A href=\"{$GLOBALS['THIS_FILE']}?Sight={$id}\">{$init->tagName_}{$name}</A>{$point}{$init->_tagName}の<strong>{$lName}側のお土産屋さん</strong>から<strong>{$value}{$str}</strong>もの収入がありました。",$id);
+    $this->out("<A href=\"{$GLOBALS['THIS_FILE']}?Sight={$id}\">{$init->tagName_}{$name}</A>{$point}{$init->_tagName}の<strong>{$lName}側のお土産屋さん</strong>から<strong>{$str}</strong>もの収入がありました。",$id);
   }
   // 収穫
   function Syukaku($id, $name, $lName, $point, $str) {

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -1451,7 +1451,7 @@ class Turn {
          ($landKind == $init->landPort) ||
          ($landKind == $init->landMountain) ||
 		 ($landKind == $init->landnMountain) ||
-         ($landKind >= 50 && $landkind < 55) ||
+         ($landKind >= 50 && $landKind < 55) ||
          ($landKind == $init->landMonster) ||
          ($landKind == $init->landSleeper) ||
          ($landKind == $init->landZorasu)) {
@@ -1639,7 +1639,7 @@ class Turn {
       // 目的の場所を海にする。山なら荒地に。浅瀬なら海に。
       if(($landKind == $init->landMountain) ||
 	  	 ($landKind == $init->landnMountain) ||
-         ($landKind >= 50 && $landkind < 55)) {
+         ($landKind >= 50 && $landKind < 55)) {
         $land[$x][$y] = $init->landWaste;
         $landValue[$x][$y] = 0;
       } elseif($landKind == $init->landSea) {
@@ -4912,7 +4912,7 @@ class Turn {
     }
 
     // 地震判定
-    if ((Util::random(1000) < (($island['prepare2'] + 1) * $init->disEarthquake) - (int)($island['eisei'][1] / 15))
+    if ((Util::random(1000) < (($island['prepare2'] + 1) * $init->disEarthquake) - (int)((int)$island['eisei'][1] / 15))
         || ($island['present']['item'] == 1)) {
       // 地震発生
       $this->log->earthquake($id, $name);
@@ -4930,12 +4930,12 @@ class Turn {
            (($landKind == $init->landHatuden) && ($lv < 100)) ||
            ($landKind == $init->landHaribote) ||
            ($landKind == $init->landSeaCity) ||
-		   ($landkind == $init->landSeeCity) ||
+		   ($landKind == $init->landSeeCity) ||
            ($landKind == $init->landSFactory) ||
            ($landKind == $init->landMFactory) ||
            ($landKind == $init->landFFactory) ||
 		   (($landKind == $init->landBigtown) && ($lv >= 100)) ||
-		   (($landkind == $init->landSeeCity) && ($lv >= 100)) ||
+		   (($landKind == $init->landSeeCity) && ($lv >= 100)) ||
            (($landKind == $init->landNewtown) && ($lv >= 100)) ||
            (($landKind == $init->landIndCity) && ($lv >= 100)) ||
 		   (($landKind == $init->landCapital) && ($lv >= 1000))) {
@@ -5058,7 +5058,7 @@ class Turn {
     }
 
     // 津波判定
-    if ((Util::random(1000) < $init->disTsunami - (int)($island['eisei'][1] / 15))
+    if ((Util::random(1000) < $init->disTsunami - (int)((int)$island['eisei'][1] / 15))
         || ($island['present']['item'] == 2)) {
       // 津波発生
       $this->log->tsunami($id, $name);
@@ -5291,7 +5291,7 @@ class Turn {
     }
 
     // 台風判定
-    if ((Util::random(1000) < ($init->disTyphoon - (int)($island['eisei'][0] / 10))) && (($island['tenki'] == 2) || ($island['tenki'] == 3))
+    if ((Util::random(1000) < ($init->disTyphoon - (int)((int)$island['eisei'][0] / 10))) && (($island['tenki'] == 2) || ($island['tenki'] == 3))
         || ($island['present']['item'] == 5)) {
       // 台風発生
       $this->log->typhoon($id, $name);
@@ -5329,7 +5329,7 @@ class Turn {
     }
 
     // 巨大隕石判定
-    if (((Util::random(1000) < ($init->disHugeMeteo - (int)($island['eisei'][2] / 50))))
+    if (((Util::random(1000) < ($init->disHugeMeteo - (int)((int)$island['eisei'][2] / 50))))
         || ($island['present']['item'] == 6)) {
 
       // 落下
@@ -5352,7 +5352,7 @@ class Turn {
     }
 
     // 隕石判定
-    if ((Util::random(1000) < ($init->disMeteo - (int)($island['eisei'][2] / 40)))
+    if ((Util::random(1000) < ($init->disMeteo - (int)((int)$island['eisei'][2] / 40)))
         || ($island['present']['item'] == 7)) {
       $first = 1;
       while((Util::random(2) == 0) || ($first == 1)) {

--- a/trade/hako-util.php
+++ b/trade/hako-util.php
@@ -543,7 +543,7 @@ class Util {
     if($number == count($command) - 1)
       return;
 
-    for($i = $init->commandMax - 1; $i >= $number; $i--) {
+    for($i = $init->commandMax - 1; $i > $number; $i--) {
       $command[$i] = $command[$i - 1];
     }
   }


### PR DESCRIPTION
### Motivation
- Prevent runtime warnings and fatal `TypeError` during turn processing caused by string/integer operations and undefined variables.
- Ensure land-kind comparisons use the correct variable name to stop repeated `Undefined variable $landkind` warnings.
- Use the correct value in the souvenir log message to avoid referencing an undefined variable.
- Avoid shifting `-1` index when moving commands to the back in `slideBack`.

### Description
- Cast satellite energy entries used in disaster probability calculations to `int` before dividing, fixing string/int `Unsupported operand types` errors in earthquake/tsunami/typhoon/huge-meteo/meteors checks in `trade/hako-turn.php`.
- Normalize variable casing by replacing `$landkind` with `$landKind` in land-type checks to remove undefined-variable warnings in `trade/hako-turn.php`.
- Fix the souvenir log function `Miyage` to print the passed amount string parameter (`$str`) instead of an undefined `$value` in `trade/hako-log.php`.
- Change the `for` loop condition in `Util::slideBack()` from `for($i = $init->commandMax - 1; $i >= $number; $i--)` to `for($i = $init->commandMax - 1; $i > $number; $i--)` to avoid reading `$command[-1]` in `trade/hako-util.php`.

### Testing
- Ran syntax checks on modified files with `php -l trade/hako-turn.php`, `php -l trade/hako-log.php`, and `php -l trade/hako-util.php`, and they all reported no syntax errors.
- Ran repository-level change check with `git diff --check` and confirmed no whitespace/merge issues on the modified files.
- Attempted a full-project PHP lint (`find trade -name '*.php' -print0 | xargs -0 -n1 php -l`), which aborted due to a pre-existing parse error in an unrelated file `trade/tests/props_0.2/display/htmltemplate.php` (unmodified by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f38eff2d88326a05ea5e4f3ceb21b)