### PR TITLE
Fix PHP 8 fatal/warning errors in HTML, Turn, Main and WNS

### DIFF
--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -23,6 +23,9 @@ class HTML {
   function header($data = "") {
     global $init;
     global $PRODUCT_VERSION;
+    if(!is_array($data)) {
+      $data = array();
+    }
 
     // 圧縮転送
     if(GZIP == true) {
@@ -39,7 +42,7 @@ class HTML {
 	$param['title'] =$init->title;
 	$param['baseDir'] = $init->baseDir;
 
-	if($data['mobile'] == true){
+	if(!empty($data['mobile'])){
 		print HTML::tplengine('./templates/mobile/head.html',$param);
 	}else{
 		$param['urlTopPage'] = $init->urlTopPage;
@@ -55,8 +58,11 @@ class HTML {
   //---------------------------------------------------
   // HTML フッタ出力
   //---------------------------------------------------
-  function footer() {
+  function footer($data = "") {
     global $init;
+    if(!is_array($data)) {
+      $data = array();
+    }
 
 	if(GZIP == true) {
       global $http;
@@ -74,8 +80,8 @@ class HTML {
         $tex = sprintf("　<SMALL>(CPU : %.6f秒)</SMALL>", $tmp4-$tmp2+$tmp3-$tmp1);
     }
 
-	$param['perform'] = $tex;
-	if($data['mobile'] == true){
+	$param['perform'] = $tex ?? '';
+	if(!empty($data['mobile'])){
 		print HTML::tplengine('./templates/mobile/footer.html',$param);
 	}else{
 		print HTML::tplengine('./templates/footer.html',$param);
@@ -138,7 +144,7 @@ END;
   //---------------------------------------------------
   // テンプレートエンジン
   //---------------------------------------------------
-	Function tplengine($tpl,$param){
+	static function tplengine($tpl,$param){
 		global $init;
 		$param = array_merge($param,$init->tplcss);
 		//テンプレートエンジン部分
@@ -534,7 +540,7 @@ if (($islandListStart != 1) || ($islandListSentinel != $hako->islandNumber)) {
 		$httool = "<div class=\"tooltip\" id=\"t{$id}\"><p id=\"comm\">{$comment}</p></div>";
 
 		$scapital = $init->Captext[$capital];
-	  	if($data['mobile'] == true){
+		if(!empty($data['mobile'])){
 			$param['banner'] = $bannerad;
 			$param['name'] = $name;
 			$param['id'] = $id;
@@ -934,7 +940,8 @@ END;
   function historyPrint() {
     print "<div id=\"HistoryLog\">\n";
     print "<h2>発見の記録</h2>";
-    LogIO::historyPrint();
+    $log = new LogIO;
+    $log->historyPrint();
     print "</div>\n";
   }
 }
@@ -2468,6 +2475,9 @@ class HtmlJS extends HtmlMap {
   function header($data = "") {
     global $init;
     global $PRODUCT_VERSION;
+    if(!is_array($data)) {
+      $data = array();
+    }
 
     // 圧縮転送
     if(GZIP == true) {
@@ -2484,7 +2494,7 @@ class HtmlJS extends HtmlMap {
 	$param['title'] =$init->title;
 	$param['baseDir'] = $init->baseDir;
 
-	if($data['mobile'] == true){
+	if(!empty($data['mobile'])){
 		print HTML::tplengine('./templates/mobile/head.html',$param);
 	}else{
 		$param['bimg'] = $bimg;

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -703,6 +703,7 @@ class LogIO {
       Util::lockr($fp);
 
       $line = array();
+      $count = 0;
       while($l = chop(fgets($fp, READ_LINE))) {
         array_push($line, $l);
         $count++;

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -1111,6 +1111,8 @@ class Turn {
     }
 	//統計前処理
 	$year = Util::MKCal($hako->islandTurn,1);
+	$nests = array();
+	$stat = array('pop' => 0, 'farm' => 0, 'ind' => 0, 'market' => 0, 'shell' => 0, 'pgoods' => 0, 'pmoneys' => 0);
 	for($i = 0; $i < $hako->islandNumber; $i++){
 	
 	$nest_country = array(
@@ -1138,18 +1140,20 @@ class Turn {
 		'DC' => 'C', 
 		'amount' => '0')
     );
-	  foreach((array)$hako->islands[$i]['nest'] as $nest_item){
-	  	$account = $nest_item['account'];
-		$nest_country[$account]['amount'] += $nest_item['amount'];
+	  foreach((array)($hako->islands[$i]['nest'] ?? array()) as $nest_item){
+		$account = $nest_item['account'] ?? null;
+		if(isset($nest_country[$account])) {
+		  $nest_country[$account]['amount'] += $nest_item['amount'] ?? 0;
+		}
 	  }
 	  $nests[] = $nest_country;
-	  $stat['pop'] += $hako->islands[$i]['pop'];
-	  $stat['farm'] += $hako->islands[$i]['farm'] * 10;
-	  $stat['ind'] += $hako->islands[$i]['factory'] * 10;
-	  $stat['market'] += $hako->islands[$i]['market'] * 10;
-      $stat['shell'] += $hako->islands[$i]['shell'];
-	  $stat['pgoods'] += $hako->islands[$i]['p_goods'];
-	  $stat['pmoneys'] += $hako->islands[$i]['p_moneys'];
+	  $stat['pop'] += $hako->islands[$i]['pop'] ?? 0;
+	  $stat['farm'] += ($hako->islands[$i]['farm'] ?? 0) * 10;
+	  $stat['ind'] += ($hako->islands[$i]['factory'] ?? 0) * 10;
+	  $stat['market'] += ($hako->islands[$i]['market'] ?? 0) * 10;
+      $stat['shell'] += $hako->islands[$i]['shell'] ?? 0;
+	  $stat['pgoods'] += $hako->islands[$i]['p_goods'] ?? 0;
+	  $stat['pmoneys'] += $hako->islands[$i]['p_moneys'] ?? 0;
     }
 
     // 島数カット
@@ -3847,7 +3851,7 @@ class Turn {
       $addpop = 0;
     } elseif(($island['siji'] + $island['hapiness']) <= 15) {
 	  //暴動発生中なら人口減少
-	  if(($island['polit'] != 2)||($island['policestat'] == 1)){
+	  if(($island['polit'] != 2)||(($island['policestat'] ?? 0) == 1)){
 	  //警察国家以外or警察スト中
 	  if (Util::random(500) < $init->disRobViking){
 			if (($hako->islandTurn - $island['starturn']) > $init->noMissile){
@@ -3917,6 +3921,7 @@ class Turn {
             continue 2;
           }
 		} else {
+		  $nsize = 0;
           // 成長
 		  if($landKind == $init->landCapital){
 		  //首都用
@@ -4830,7 +4835,7 @@ class Turn {
 
       // 自動輸送系
       // 記録済みベースデータ取得
-	$regT = $island['regT'];//輸送データ取得
+	$regT = $island['regT'] ?? array();//輸送データ取得
 
 	if($island['bport'] > 0){
 	  //大規模港が存在する場合自動輸送20本
@@ -4847,12 +4852,17 @@ class Turn {
 			$fport = true;
                list($target,$kind,$arg) = explode(",", $regT[$i]);
 
+			if(!isset($hako->idToNumber[$target])){
+			  //対象国が存在しない時はログなしでループを飛ばす
+			  $fport = false;
+			  continue;
+			}
 			$cost = $init->comCost[$kind];//コストを取得
 			$tn = $hako->idToNumber[$target];//ターゲットナンバー取得
 			$mn = $hako->idToNumber[$id];//自国ナンバー取得
 			$tIsland = &$hako->islands[$tn];//ターゲット国変数一括取得
-			$tName = $tIsland['name'];//ターゲット名取得
-			$tport = $tIsland['port']+$tIsland['bport'];//ターゲット国港数取得
+			$tName = $tIsland['name'] ?? '';//ターゲット名取得
+			$tport = ($tIsland['port'] ?? 0)+($tIsland['bport'] ?? 0);//ターゲット国港数取得
 			$comName = $init->comName[$kind];
 
 		  $container = "";//参照渡し用
@@ -5563,7 +5573,7 @@ class Turn {
 		$rflag = false;
 	}
 	// 幸福度デモ&暴動
-	if($rflag = true){
+	if($rflag == true){
 	if(!empty($island['riot'])) {
 				//暴動発生
 			        if(!($island['money'] < $init->disVikingMinMoney)){
@@ -5576,12 +5586,12 @@ class Turn {
 			        	}
 		    } elseif (($island['siji'] + $hapiness) <= 25) {
 			 // デモメッセージ
-			 if(($island['polit'] != 2)||($island['policestat'] == 1)){
+			 if(($island['polit'] != 2)||(($island['policestat'] ?? 0) == 1)){
 		      	$this->log->gvDemo($id, $name);
 			  }
 			} elseif (($island['siji'] + $hapiness) <= 35) {
 			// 警告メッセージ
-			 if(($island['polit'] != 2)||($island['policestat'] == 1)){
+			 if(($island['polit'] != 2)||(($island['policestat'] ?? 0) == 1)){
 			 	$this->log->gvAlert($id, $name);
 				}
 			}
@@ -7144,7 +7154,8 @@ function AutoNews($id,$name,$turn,$text,$category){
 	$dataset['author']	 = "国際ニュースネット/".$name;
 	$dataset['ip']		 = "0.0.0.0";
 
-	Make::NewsPost($dataset);
+	$make = new Make;
+	$make->NewsPost($dataset);
 }
 
 }

--- a/trade/wns.php
+++ b/trade/wns.php
@@ -11,15 +11,15 @@ var $items = array("newsID"=>'',"nationID"=>'',"category"=>'',"text"=>'',"date"=
 function Updater($datas){
 	$this->items = array_merge($this->items,$datas);
 	$this->items['date'] = date("Y-m-d\TH:i:sO");
-	$newID = WNSsys::WriteXML($this->items);
-	WNSsys::UpdateRSS($newID);
+	$newID = $this->WriteXML($this->items);
+	$this->UpdateRSS($newID);
 }
 function WriteXML($newdata){
 	$xml = new SimpleXMLElement($this->xmlpath,NULL,TRUE);
 	$fp = fopen($this->xmlpath, 'a');
 	Util::lockw($fp);//追記処理中はロック
 //追記処理
-	$newdata['newsID'] = WNSsys::XMLcounter($xml);
+	$newdata['newsID'] = $this->XMLcounter($xml);
 	$addnews = $xml->addChild('item');
 	foreach($newdata as $key => $val){
 		$addnews->addChild($key,$val);
@@ -38,7 +38,7 @@ function UpdateRSS($newID){
 	$rss->link = "https://tanstafl.sakura.ne.jp/";
 	$rss->syndicationURL = "https://tanstafl.sakura.ne.jp/".$PHP_SELF;
 	
-	$newall = WNSsys::LatestRSS();
+	$newall = $this->LatestRSS();
 	
 	foreach($newall as $eachdats){
 			$item = new FeedItem();
@@ -56,7 +56,7 @@ function UpdateRSS($newID){
 	
 function LatestRSS(){
 	$alldats = simplexml_load_file($this->xmlpath);
-	$newID = WNSsys::XMLcounter($alldats);
+	$newID = $this->XMLcounter($alldats);
 	$count = 1;
 	foreach($alldats as $key => $eachdats){
 		if($newID < $count+16){
@@ -78,7 +78,7 @@ function XMLcounter($xml){
 
 function MakeHTML($request,$basepath){
 //閲覧用にリスト形式のニュースを出力
-		$newall = WNSsys::LatestRSS();
+		$newall = $this->LatestRSS();
 		$count = 0;
 		$html = "<ul id=\"latestnews\">\n";
 			$path = $basepath.substr($this->rsspath,1);


### PR DESCRIPTION
### Motivation
- Resolve PHP 8 runtime errors and repeated warnings found in `error_log/log_2026060303.txt` by guarding undefined array keys, avoiding invalid static calls, and fixing accidental assignments in conditionals.
- Make template rendering and history logging robust when optional header/footer data or template parameters are missing.

### Description
- In `trade/hako-html.php` normalize optional `$data` for `header()`/`footer()`, treat `mobile` with `!empty()`, make `tplengine()` static and replace the static `LogIO::historyPrint()` call with an instance call to avoid non-static invocation errors.
- In `trade/hako-main.php` initialize the `$count` variable in `historyTrim()` to prevent undefined-variable warnings during file reads.
- In `trade/hako-turn.php` initialize `$nests` and `$stat`, use null-coalesce guards for `nest`, `regT` and island fields, add a check for missing target IDs in automatic transport, set a default `$nsize`, fix `if($rflag = true)` to `if($rflag == true)`, and convert static `Make::NewsPost()` calls to an instance call path to avoid non-static method problems.
- In `trade/wns.php` convert class-style static calls inside the class to instance-based calls by replacing `WNSsys::`/`WNSsys::XMLcounter`/`WNSsys::LatestRSS` usages with `$this->` equivalents to ensure proper method resolution.

### Testing
- Ran `php -l` on the modified files `trade/hako-html.php`, `trade/hako-main.php`, `trade/hako-turn.php` and `trade/wns.php`, and each file reported no syntax errors (success).
- Attempted a full-project `php -l` scan but it failed due to a preexisting unrelated parse error in `trade/configs/resources.domain.php`, so global lint across all files did not complete (expected failure unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3e0d5c888326bbdb3dcd349ee337)