### PR TITLE
Fix admin maintenance menu initialization

### DIFF
--- a/trade/hako-admin.php
+++ b/trade/hako-admin.php
@@ -53,7 +53,7 @@ class Main {
   var $urllist = array();
   var $menulist = array();
 
-  function Main() {
+  function __construct() {
     $this->urllist = array( ini_get('safe_mode') ? '/hako-mente-safemode.php' : '/hako-mente.php', '/hako-axes.php', '/hako-present.php', '/hako-edit.php');
     $this->menulist = array('データ管理','アクセスログ閲覧','プレゼント','マップエディタ');
   }


### PR DESCRIPTION
### Motivation
- 管理画面のメンテナンス用プルダウンが項目表示されない原因は、`Main` クラスが PHP4 形式の旧コンストラクタ `function Main()` を使っており、PHP8 環境でコンストラクタが呼ばれず `$urllist` / `$menulist` が初期化されなかったためです。

### Description
- `trade/hako-admin.php` の `function Main()` を `function __construct()` に変更して、インスタンス生成時に `$urllist` と `$menulist` を確実に初期化するようにしました（管理メニューのプルダウン項目復活）。

### Testing
- `php -l trade/hako-admin.php` を実行して構文チェックを行い成功しました。
- `(cd trade && php -d display_errors=1 hako-admin.php > /tmp/admin-fixed.html 2>/tmp/admin-fixed.err)` を実行して出力 HTML を確認し、`rg -n "<select|<option|データ管理|アクセスログ" /tmp/admin-fixed.html` によりプルダウン項目が出力されることを確認しました（いずれも成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f40f8ae148326ba764db179b461b4)