### PR TITLE
Fix PHP warnings and fatal errors reported in error_log/log_2026060304.txt

### DIFF
--- a/trade/feedcreator/include/feedcreator.class.php
+++ b/trade/feedcreator/include/feedcreator.class.php
@@ -50,11 +50,11 @@ v1.7	07-18-04
 	added a switch to select an external stylesheet (thanks to Pascal Van Hecke)
 	changed default content-type to application/xml
 	added character encoding setting
-	fixed numerous smaller bugs (thanks to Söòen Fuhrmann of golem.de)
+	fixed numerous smaller bugs (thanks to SÃ¶Ã²en Fuhrmann of golem.de)
 	improved changing ATOM versions handling (thanks to August Trometer)
-	improved the UniversalFeedCreator's useCached method (thanks to Söòen Fuhrmann of golem.de)
-	added charset output in HTTP headers (thanks to Söòen Fuhrmann of golem.de)
-	added Slashdot namespace to RSS 1.0 (thanks to Söòen Fuhrmann of golem.de)
+	improved the UniversalFeedCreator's useCached method (thanks to SÃ¶Ã²en Fuhrmann of golem.de)
+	added charset output in HTTP headers (thanks to SÃ¶Ã²en Fuhrmann of golem.de)
+	added Slashdot namespace to RSS 1.0 (thanks to SÃ¶Ã²en Fuhrmann of golem.de)
 
 v1.6	05-10-04
 	added stylesheet to RSS 1.0 feeds
@@ -72,7 +72,7 @@ v1.6 beta	02-28-04
 	considered beta due to some internal changes
 
 v1.5.1	01-27-04
-	fixed some RSS 1.0 glitches (thanks to Stéðhane Vanpoperynghe)
+	fixed some RSS 1.0 glitches (thanks to StÃ©Ã°hane Vanpoperynghe)
 	fixed some inconsistencies between documentation and code (thanks to Timothy Martin)
 
 v1.5	01-06-04
@@ -603,6 +603,12 @@ class FeedCreator extends HtmlDescribable {
 	* Ignored in the output when empty.
 	*/
 	var $xslStyleSheet = "";
+
+	/**
+	* The url of the external css stylesheet used to format the naked feed.
+	* Ignored in the output when empty.
+	*/
+	var $cssStyleSheet = "";
 	
 	
 	/**

--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -2620,7 +2620,7 @@ class HtmlJS extends HtmlMap {
           }
           $All_listCom++;
         }
-        if($l_kind < $ff+1) { next; }
+        if($l_kind < $ff+1) { continue; }
       }
       $bai = strlen($set_listcom);
       $set_listcom = substr($set_listcom, 0, $bai - 2);

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -3910,6 +3910,11 @@ class Turn {
 		// 観光都市
 		// 現代都市
 		// 首都
+        $nsize = 0;
+        if($landKind == $init->landCapital){
+          //首都用
+          $nsize = ($island['capital']-1)*2;
+        }
         if($addpop < 0) {
           // 不足
           $lv -= Util::random(-$addpop) + 1;
@@ -3921,14 +3926,7 @@ class Turn {
             continue 2;
           }
 		} else {
-		  $nsize = 0;
           // 成長
-		  if($landKind == $init->landCapital){
-		  //首都用
-		  	$nsize = ($island['capital']-1)*2;
-		  }else{
-		  	$nsize = 0;
-		  }
 		  if($landKind == $init->landTown){
 		  	//大都市成長カウント用
 		  	$townCount = Turn::countAround($land, $x, $y, $init->landBigtown, 7);

--- a/trade/wns.php
+++ b/trade/wns.php
@@ -36,7 +36,7 @@ function UpdateRSS($newID){
 	$rss->title = "フリューゲル共同通信";
 	$rss->description = "貿易版箱庭諸国の最新ニュースをお届けします";
 	$rss->link = "https://tanstafl.sakura.ne.jp/";
-	$rss->syndicationURL = "https://tanstafl.sakura.ne.jp/".$PHP_SELF;
+	$rss->syndicationURL = "https://tanstafl.sakura.ne.jp/" . ($_SERVER['PHP_SELF'] ?? '');
 	
 	$newall = $this->LatestRSS();
 	


### PR DESCRIPTION
### Motivation
- Address PHP notices/warnings and a fatal error found in the log that stem from undefined variables/properties and an invalid loop control statement.
- Make small defensive changes so feed generation and turn processing no longer reference missing identifiers or use invalid tokens.

### Description
- Replace legacy/undefined `$PHP_SELF` usage in `trade/wns.php` with a safe `$_SERVER['PHP_SELF']` fallback when constructing `syndicationURL`.
- Declare a missing `var $cssStyleSheet = "";` property in `trade/feedcreator/include/feedcreator.class.php` so stylesheet reference generation will not raise an undefined property notice.
- Initialize and set `$nsize` before branches in `trade/hako-turn.php` so subsequent bounds checks use a defined index even when population decreases.
- Replace the invalid bare `next;` token in `trade/hako-html.php` with the correct PHP loop control `continue;` to avoid a runtime fatal error.

### Testing
- Ran PHP syntax checks with `php -d short_open_tag=1 -l` on `trade/wns.php`, `trade/feedcreator/include/feedcreator.class.php`, `trade/hako-turn.php`, and `trade/hako-html.php`, and they all reported no syntax errors.
- Executed `php -d short_open_tag=1 -d error_reporting=E_ALL -r 'require "trade/feedcreator/include/feedcreator.class.php"; $feed = new AtomCreator10(); echo $feed->_createStylesheetReferences();'` which ran without errors.
- Loaded `trade/wns.php` in a CLI-representative environment with `php -d short_open_tag=1 -d error_reporting=E_ALL -r '$_SERVER["PHP_SELF"] = "/trade/wns.php"; chdir("trade"); require "wns.php";'` which executed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4344b50c8326ae28fad4bd2b4e6b)