### PR TITLE
feedcreatorのAtomフィードでUTF-8が使われない問題を修正

### DIFF
--- a/trade/feedcreator/include/feedcreator.class.php
+++ b/trade/feedcreator/include/feedcreator.class.php
@@ -1252,6 +1252,10 @@ class PIECreator01 extends FeedCreator {
  */
  class AtomCreator10 extends FeedCreator {
  
+	function __construct() {
+		$this->AtomCreator10();
+	}
+
 	function AtomCreator10() {
 		$this->contentType = "application/atom+xml";
 		$this->encoding = "utf-8";

--- a/trade/feedcreator/news/.htaccess
+++ b/trade/feedcreator/news/.htaccess
@@ -1,0 +1,2 @@
+AddType application/atom+xml; charset=UTF-8 .xml
+AddCharset UTF-8 .xml

--- a/trade/wns.php
+++ b/trade/wns.php
@@ -32,6 +32,7 @@ function WriteXML($newdata){
 function UpdateRSS($newID){
 	//ニュースをRSSファイルに書き出す
 	$rss = new UniversalFeedCreator();
+	$rss->encoding = "UTF-8";
 	$rss->useCached();
 	$rss->title = "フリューゲル共同通信";
 	$rss->description = "貿易版箱庭諸国の最新ニュースをお届けします";


### PR DESCRIPTION
### Motivation
- Atomフィード生成クラス`AtomCreator10`が旧式のPHP4コンストラクタのみで定義されており、PHP 8系で初期化処理が呼ばれず`encoding`/`contentType`が期待どおりに設定されないため文字化けが発生していました。 
- 静的に配信される生成済み`.xml`に対してAtom用のContent-Type/charsetが明示されておらず、クライアント側で誤認識される可能性がありました。

### Description
- `AtomCreator10`にPHP8互換の`__construct()`を追加して既存の初期化メソッドを呼ぶようにし、`contentType`と`encoding`の初期化を確実に行うようにしました（`trade/feedcreator/include/feedcreator.class.php`）。
- フィード生成時に明示的にUTF-8を使うため、`trade/wns.php`のフィード生成処理で`$rss->encoding = "UTF-8";`をセットするようにしました。 
- 生成済みフィード配信ディレクトリ`trade/feedcreator/news/`に`.htaccess`を追加して`.xml`を`application/atom+xml; charset=UTF-8`として配信するようにしました（`AddType` / `AddCharset`）。

### Testing
- 実行ファイルの構文チェックで`php -l trade/wns.php`が成功しました。 
- クラスファイルの構文チェックで`php -l trade/feedcreator/include/feedcreator.class.php`が成功しました。 
- 小さなPHPスニペットで`include

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e50879cfc83268a125ac134f725e5)