### PR TITLE
Add nation flag upload feature with validation, UI, and security hardening

### DIFF
--- a/trade/hako-file.php
+++ b/trade/hako-file.php
@@ -219,7 +219,7 @@ class HakoIO {
 	  'capital'  => (int)$capital,
 	  'Cname'    => $Cname,
 	  'edinv'    => (int)$edinv,
-	  'banum'	 => (int)$banum,
+	  'banum'	 => trim($banum),
 	  'cmente'	 => (int)$cmente,
 	  'indnum'	 => (int)$indnum,
 	  'polit'	 => (int)$polit,

--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -507,7 +507,7 @@ if (($islandListStart != 1) || ($islandListSentinel != $hako->islandNumber)) {
 		}
 		$owner =  "<br>{$init->tagTH_}元首：{$owner}{$init->_tagTH}";
 		$bannerad = "img/up/log";
-		if (file_exists($bannerad.'/'.$banum.'.png')){
+		if (preg_match('/^[A-Za-z0-9_-]+$/', $banum) && file_exists($bannerad.'/'.$banum.'.png')){
 			$bannerad = 'up/log/'.$banum.'.png';
 			$bannerad = "<IMG SRC=\"{$bannerad}\" width=\"45\" height=\"30\"align=\"left\" title=\"{$pname}旗\" ALT=\"{$pname}旗\">";
 		}else{
@@ -1204,7 +1204,7 @@ END;
 	$socad .="<IMG SRC=\"socsec.png\" width=\"20\" height=\"20\" title=\"社会保障指数：{$soclv}\" ALT=\"社会保障指数：{$soclv}\"> {$soclv}";
 
 	$bannerad = "img/up/log";
-	if (file_exists($bannerad.'/'.$banum.'.png')){
+	if (preg_match('/^[A-Za-z0-9_-]+$/', $banum) && file_exists($bannerad.'/'.$banum.'.png')){
 		$bannerad = 'up/log/'.$banum.'.png';
 		$bannerad = "<IMG align = \"center\" SRC=\"{$bannerad}\" width=\"45\" height=\"30\"align=\"left\" title=\"{$pname}旗\" ALT=\"{$pname}旗\">";
 	}else{
@@ -2157,7 +2157,7 @@ $param['PAS'] =   $data['PASSWORD'];
 $param['id']  = $island['id'];
 $param['news_point']  = $island['news_point'];
 $param['CNAM'] =  $island['Cname'];
-$param['num'] =  $island['banum'];
+$param['num'] =  htmlspecialchars($island['banum']);
 $param['wiki_link'] =  $island['wiki_link'];
 $param['trade_link'] =  $island['trade_link'];
 $param['news_link'] =  $island['news_link'];
@@ -3533,7 +3533,7 @@ $param['PAS'] =   $data['PASSWORD'];
 $param['id']  = $island['id'];
 $param['news_point']  = $island['news_point'];
 $param['CNAM'] =  $island['Cname'];
-$param['num'] =  $island['banum'];
+$param['num'] =  htmlspecialchars($island['banum']);
 $param['wiki_link'] =  $island['wiki_link'];
 $param['trade_link'] =  $island['trade_link'];
 $param['news_link'] =  $island['news_link'];
@@ -3921,6 +3921,12 @@ class HakoError {
   public static function changeNothing() {
     global $init;
     print "{$init->tagBig_}名前、パスワードともに空欄です{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
+    HTML::footer();
+    exit;
+  }
+  public static function flagUploadError($message) {
+    global $init;
+    print "{$init->tagBig_}" . htmlspecialchars($message) . "{$init->spanend}{$GLOBALS['BACK_TO_TOP']}\n";
     HTML::footer();
     exit;
   }

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -1106,6 +1106,12 @@ class Main {
       $html->footer();
       break;
 
+    case "flagUpload":
+      $html->header($cgi->dataSet);
+      $com->flagUpload($hako, $cgi->dataSet);
+      $html->footer();
+      break;
+
     case "print":
       $html->header($cgi->dataSet);
       $html->visitor($hako, $cgi->dataSet);

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -246,6 +246,10 @@ class Make {
   //---------------------------------------------------
   function commentMain($hako, $data) {
     $id  = $data['ISLANDID'];
+    if(!preg_match('/^[0-9]+$/', $id) || !isset($hako->idToNumber[$id])) {
+      HakoError::wrongID();
+      return;
+    }
     $num = $hako->idToNumber[$id];
     $island = $hako->islands[$num];
     $name = $island['name'];
@@ -370,10 +374,9 @@ class Make {
 	    break;
 	    
     	case "Banner":
-   		//国旗番号を更新
-	    $island['banum'] = htmlspecialchars($data['Number']);
-		$msg = "国旗";
-	    break;
+		//国旗番号の直接更新は廃止
+	    HakoError::flagUploadError('国旗ファイルIDは直接変更できません。国旗画像アップロード機能を利用してください。');
+	    return;
 
     	case "Wiki_Link":
 	    //Wikiリンクを更新
@@ -412,6 +415,118 @@ class Make {
     }
     $html->owner($hako, $data);
 	}
+
+  //---------------------------------------------------
+  // 国旗画像アップロード
+  //---------------------------------------------------
+  function flagUpload($hako, $data) {
+    $id  = $data['ISLANDID'];
+    if(!preg_match('/^[0-9]+$/', $id) || !isset($hako->idToNumber[$id])) {
+      HakoError::wrongID();
+      return;
+    }
+    $num = $hako->idToNumber[$id];
+    $island = $hako->islands[$num];
+
+    if(!Util::checkPassword($island['password'], $data['PASSWORD'])) {
+      HakoError::wrongPassword();
+      return;
+    }
+
+    if(!isset($_FILES['FLAGFILE']) || !is_array($_FILES['FLAGFILE'])) {
+      HakoError::flagUploadError('国旗画像が選択されていません。');
+      return;
+    }
+
+    $file = $_FILES['FLAGFILE'];
+    if($file['error'] != UPLOAD_ERR_OK) {
+      HakoError::flagUploadError('国旗画像のアップロードに失敗しました。');
+      return;
+    }
+
+    $maxBytes = 65536;
+    if($file['size'] <= 0 || $file['size'] > $maxBytes) {
+      HakoError::flagUploadError('国旗画像は64KB以下にしてください。');
+      return;
+    }
+
+    $imageInfo = @getimagesize($file['tmp_name']);
+    if($imageInfo === false) {
+      HakoError::flagUploadError('画像ファイルを読み取れません。');
+      return;
+    }
+
+    $width = $imageInfo[0];
+    $height = $imageInfo[1];
+    $type = $imageInfo[2];
+    if($width < 1 || $height < 1 || $width > 1200 || $height > 800) {
+      HakoError::flagUploadError('国旗画像のサイズは最大1200×800ピクセルです。');
+      return;
+    }
+
+    if($type != IMAGETYPE_PNG && $type != IMAGETYPE_JPEG) {
+      HakoError::flagUploadError('アップロードできる国旗画像はPNGまたはJPEGです。');
+      return;
+    }
+
+    if(!function_exists('imagecreatetruecolor')) {
+      HakoError::flagUploadError('画像変換機能が利用できません。');
+      return;
+    }
+
+    if($type == IMAGETYPE_PNG) {
+      $src = @imagecreatefrompng($file['tmp_name']);
+    } else {
+      $src = @imagecreatefromjpeg($file['tmp_name']);
+    }
+    if(!$src) {
+      HakoError::flagUploadError('国旗画像を変換できません。');
+      return;
+    }
+
+    $dstWidth = 45;
+    $dstHeight = 30;
+    $dst = imagecreatetruecolor($dstWidth, $dstHeight);
+    imagealphablending($dst, false);
+    imagesavealpha($dst, true);
+    $transparent = imagecolorallocatealpha($dst, 255, 255, 255, 127);
+    imagefilledrectangle($dst, 0, 0, $dstWidth, $dstHeight, $transparent);
+    imagecopyresampled($dst, $src, 0, 0, 0, 0, $dstWidth, $dstHeight, $width, $height);
+
+    $flagId = 'bn-' . $id;
+    $uploadDir = dirname(__FILE__) . '/img/up/log';
+    if(!is_dir($uploadDir) || !is_writable($uploadDir)) {
+      imagedestroy($src);
+      imagedestroy($dst);
+      HakoError::flagUploadError('国旗画像の保存先に書き込めません。');
+      return;
+    }
+
+    $savePath = $uploadDir . '/' . $flagId . '.png';
+    if(!imagepng($dst, $savePath)) {
+      imagedestroy($src);
+      imagedestroy($dst);
+      HakoError::flagUploadError('国旗画像を保存できません。');
+      return;
+    }
+    chmod($savePath, 0604);
+    imagedestroy($src);
+    imagedestroy($dst);
+
+    $island['banum'] = $flagId;
+    $hako->islands[$num] = $island;
+    $hako->writeIslandsFile();
+
+    HtmlSetted::Capital('国旗');
+
+    if($data['DEVELOPEMODE'] == "cgi") {
+      $html = new HtmlMap;
+    } else {
+      $html = new HtmlJS;
+    }
+    $html->owner($hako, $data);
+  }
+
   //---------------------------------------------------
   // ローカル掲示板モード
   //---------------------------------------------------

--- a/trade/templates/banners.html
+++ b/trade/templates/banners.html
@@ -53,22 +53,114 @@
 		</div>
 
 		<div id='Banner'>
-		<h2>国旗番号入力</h2>
-		<form action="{GLTH}" method="post">
-		国旗番号<input type="text" name="Number" size="5" maxlength="3" value="{num}"><br>
+		<h2>国旗設定</h2>
+		<p>現在の国旗ファイルID：<input type="text" name="Number" size="10" maxlength="20" value="{num}" readonly>
+		（旧IDは数字のみ、新IDは bn- で始まります）</p>
+		<form action="{GLTH}" method="post" enctype="multipart/form-data" id="FlagUploadForm">
+		<div id="FlagDropArea" style="border:2px dashed #999;padding:12px;text-align:center;cursor:pointer;">
+		国旗画像をここへドラッグ＆ドロップ、またはクリックして選択<br>
+		<input type="file" name="FLAGFILE" id="FlagFile" accept="image/png,image/jpeg" style="margin-top:8px;">
+		<div id="FlagFileInfo" style="margin-top:8px;">未選択</div>
+		<img id="FlagPreview" src="" alt="国旗プレビュー" style="display:none;margin-top:8px;max-width:180px;max-height:120px;">
+		</div>
+		<input type="hidden" name="MAX_FILE_SIZE" value="65536">
 		<input type="hidden" name="PASSWORD" value="{PAS}">
-		<input type="hidden" name="mode" value="Cname">
-		<input type="hidden" name="type" value="Banner">
+		<input type="hidden" name="mode" value="flagUpload">
 		<input type="hidden" name="DEVELOPEMODE" value="{mode}">
 		<input type="hidden" name="ISLANDID" value="{id}">
-		<input type="submit" value="国旗番号確定">
+		<input type="submit" value="国旗画像アップロード">
 		</form>
-		<a href="/trade/img/up/">国旗ファイルはここからアップロード</a>
-		<p>サイズは任意。ただし表示サイズは45×30ピクセル固定<br>
-		ファイルサイズは4KB以下<br>
-		ファイル形式はPNGのみ<br>
-		手順：アップロード⇒ファイル番号をこのページで入力<br>
-		<b>ファイル番号は半角英数字</b></p>
+		<p>アップロード後のファイルIDは <b>bn-{id}</b> に自動設定されます。<br>
+		アップロード可能形式は PNG/JPEG、容量は64KB以下、画像サイズは最大1200×800ピクセルです。<br>
+		保存時に45×30ピクセルのPNGへ変換します。<br>
+		互換性維持のため、データファイルに記載済みの旧ファイルIDもそのまま表示できますが、ユーザーによる直接書き換えはできません。</p>
+		<script>
+		(function() {
+		  var dropArea = document.getElementById('FlagDropArea');
+		  var fileInput = document.getElementById('FlagFile');
+		  var fileInfo = document.getElementById('FlagFileInfo');
+		  var preview = document.getElementById('FlagPreview');
+		  var form = document.getElementById('FlagUploadForm');
+		  var maxBytes = 65536;
+		  var maxWidth = 1200;
+		  var maxHeight = 800;
+		  var currentFileValid = false;
+		  if (!dropArea || !fileInput) return;
+
+		  function rejectFile(message) {
+		    currentFileValid = false;
+		    fileInfo.textContent = message;
+		    preview.removeAttribute('src');
+		    preview.style.display = 'none';
+		  }
+
+		  function showFile(file) {
+		    currentFileValid = false;
+		    if (!file) return;
+		    if (file.size > maxBytes) {
+		      rejectFile('ファイルサイズは64KB以下にしてください。');
+		      return;
+		    }
+		    if (file.type !== 'image/png' && file.type !== 'image/jpeg') {
+		      rejectFile('PNGまたはJPEGを選択してください。');
+		      return;
+		    }
+		    fileInfo.textContent = file.name + ' (' + Math.ceil(file.size / 1024) + 'KB)';
+		    if (window.FileReader) {
+		      var reader = new FileReader();
+		      reader.onload = function(e) {
+		        var image = new Image();
+		        image.onload = function() {
+		          if (image.width > maxWidth || image.height > maxHeight) {
+		            rejectFile('画像サイズは最大1200×800ピクセルです。');
+		            return;
+		          }
+		          currentFileValid = true;
+		          preview.src = e.target.result;
+		          preview.style.display = 'inline-block';
+		        };
+		        image.onerror = function() {
+		          rejectFile('画像ファイルを読み取れません。');
+		        };
+		        image.src = e.target.result;
+		      };
+		      reader.readAsDataURL(file);
+		    } else {
+		      currentFileValid = true;
+		    }
+		  }
+
+		  dropArea.addEventListener('click', function(e) {
+		    if (e.target !== fileInput) fileInput.click();
+		  });
+		  dropArea.addEventListener('dragover', function(e) {
+		    e.preventDefault();
+		    dropArea.style.backgroundColor = '#eef';
+		  });
+		  dropArea.addEventListener('dragleave', function() {
+		    dropArea.style.backgroundColor = '';
+		  });
+		  dropArea.addEventListener('drop', function(e) {
+		    e.preventDefault();
+		    dropArea.style.backgroundColor = '';
+		    if (e.dataTransfer.files.length) {
+		      fileInput.files = e.dataTransfer.files;
+		      showFile(e.dataTransfer.files[0]);
+		    }
+		  });
+		  fileInput.addEventListener('change', function() {
+		    showFile(fileInput.files[0]);
+		  });
+		  if (form) {
+		    form.addEventListener('submit', function(e) {
+		      if (!fileInput.files.length || !currentFileValid) {
+		        e.preventDefault();
+		        alert('アップロード可能な国旗画像を選択してください。');
+		      }
+		    });
+		  }
+		})();
+		</script>
 		</div>
 		
 		<div id='Wiki_link'>


### PR DESCRIPTION
### Motivation
- Provide a safe, user-friendly way for owners to upload nation flag images and stop direct manual edits of the flag ID in data files.
- Prevent unsafe banner filename usage and ensure banner values passed to templates are escaped.
- Add input validation on island ID for comment operations to reduce invalid accesses.

### Description
- Implemented a `flagUpload` handler in the server-side controller to accept `FLAGFILE`, validate file size/type/dimensions, convert and resize to 45×30 PNG, save under `img/up/log/bn-<ISLANDID>.png`, set file permissions, update the island `banum`, and persist islands file; errors go through a new `HakoError::flagUploadError` helper.
- Added route handling for `mode=flagUpload` in the main dispatcher and replaced the old direct Banner write in `Capitalname` to return an error instructing users to use the upload flow instead.
- Hardened banner usage: changed storage of `banum` to `trim($banum)`, escaped `banum` via `htmlspecialchars` before passing to templates, and guarded `file_exists()` calls with a safe regex check `preg_match('/^[A-Za-z0-9_-]+$/', $banum)`.
- Added client-side upload UI in `templates/banners.html` with drag-and-drop, preview, client validation (size/type/dimensions), `MAX_FILE_SIZE=65536`, and changed the submit `mode` to `flagUpload`.
- Added input validation in `commentMain` to verify the `ISLANDID` is numeric and exists before proceeding.

### Testing
- Ran PHP syntax checks on modified files with `php -l` and confirmed no syntax errors.
- Performed an automated upload test against a local dev instance with `curl` to `?` posting a small PNG to `mode=flagUpload` (using `-F "FLAGFILE=@test.png"`), and the handler accepted, resized, and saved the PNG as `bn-<id>.png` and updated the island data file (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326c815a708326b730c1914ecda9cd)