### PR TITLE
国情報と開発画面のモバイル表示を改善

### DIFF
--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -328,9 +328,33 @@ h2.Turn {
   width: 40%;
 }
 
+.register-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  margin-top: 8px;
+  padding: 7px 14px;
+  color: #ffffff;
+  background: var(--nd-color-primary);
+  border: 1px solid var(--nd-color-primary-dark);
+  border-radius: var(--nd-radius-sm);
+  box-shadow: var(--nd-shadow-sm);
+  font-weight: 700;
+}
+
+.register-button:visited,
+.register-button:hover {
+  color: #ffffff;
+  background: var(--nd-color-primary-dark);
+}
+
 #IslandView {
   clear: both;
-  width: min(99%, 1080px);
+  box-sizing: border-box;
+  width: min(100%, 1080px);
+  padding-right: 8px;
+  padding-left: 8px;
   overflow-x: auto;
 }
 
@@ -396,12 +420,21 @@ h2.Turn {
   margin-left: auto;
 }
 
+#islandMap td {
+  padding: 0;
+  font-size: 0;
+  line-height: 0;
+  white-space: nowrap;
+}
+
 .mapchip {
+  display: inline-block;
   width: 32px;
   height: 32px;
 }
 
 .subchip {
+  display: inline-block;
   width: 16px;
   height: 32px;
 }
@@ -424,6 +457,31 @@ h2.Turn {
 
 #localBBS center {
   text-align: left;
+}
+
+/* SECTION: Owner screen lower panels
+ * 定期輸送・収支・コメント編集はPCでは2列、狭い画面では1列に並べます。
+ */
+#TradeBox,
+#BalanceOut,
+#toyBox {
+  box-sizing: border-box;
+  float: left;
+  width: 50%;
+  padding: 0 8px;
+}
+
+#TradeBox table,
+#BalanceOut table,
+#toyBox table {
+  max-width: 100%;
+}
+
+#toyBox textarea,
+#toyBox input[type="text"],
+#TradeBox input[type="text"],
+#TradeBox select {
+  max-width: 100%;
 }
 
 /* SECTION: Semantic text colors
@@ -696,14 +754,24 @@ div.tooltip span {
   }
 
   #LinkHeader {
-    margin: 6px;
+    width: 100%;
+    margin: 0;
+    padding: 6px;
   }
 
   #LinkHeader ul {
+    width: 100%;
     gap: 4px;
   }
 
+  #LinkHeader li {
+    flex: 1 1 calc(50% - 4px);
+  }
+
   #LinkHeader li a {
+    box-sizing: border-box;
+    justify-content: center;
+    width: 100%;
     min-height: 38px;
     padding: 6px 9px;
   }
@@ -729,8 +797,8 @@ div.tooltip span {
   }
 
   #Loginbox {
-    width: calc(100% - 12px);
-    margin: 8px 6px;
+    width: 100%;
+    margin: 8px 0;
   }
 
   #login,
@@ -756,6 +824,19 @@ div.tooltip span {
     height: 370px;
   }
 
+  #IslandView {
+    width: 100%;
+    padding-right: 4px;
+    padding-left: 4px;
+  }
+
+  #WorldTotal,
+  #islandInfo table,
+  #CommentBox table,
+  #localBBS table {
+    width: 100%;
+  }
+
   .mapchip {
     width: 16px;
     height: 16px;
@@ -778,5 +859,22 @@ div.tooltip span {
   .visualize {
     margin-right: 8px;
     margin-left: 8px;
+  }
+
+  #TradeBox,
+  #BalanceOut,
+  #toyBox {
+    float: none;
+    width: 100%;
+    padding: 0 6px;
+    overflow-x: auto;
+  }
+
+  #TradeBox table,
+  #BalanceOut table,
+  #toyBox table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
   }
 }

--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -206,7 +206,7 @@ END;
 	</div>
 	<div ID="Register">
 		新規登録
-		<a href="https://tanstaafl.tokyo/%e3%83%ad%e3%83%bc%e3%82%ab%e3%83%ab%e3%83%ab%e3%83%bc%e3%83%ab/"><img src="regist.png"></a>
+		<a class="register-button" href="https://tanstaafl.tokyo/%e3%83%ad%e3%83%bc%e3%82%ab%e3%83%ab%e3%83%ab%e3%83%bc%e3%83%ab/">新規登録へ進む</a>
 	</div>
 </div>
 
@@ -963,12 +963,12 @@ class HtmlMap extends HTML {
     for($i=0; $i<$ax; $i++) fputs($fp,$log[$i]);
     fclose($fp);
 
-      print "<div id=\"TradeBox\" style=\"float:left; width:50%\">\n";
+      print "<div id=\"TradeBox\">\n";
 	  $this->regTHead($island);
       $this->regTInputOW($hako,$island, $data);
       $this->regTContents($hako, $island);
       print "</div>\n";
-      print "<div id=\"BalanceOut\" style=\"float:left; width:50%\">\n";
+      print "<div id=\"BalanceOut\">\n";
 	  $this->BalanceOutput($hako,$island);
       print "</div>\n";
 
@@ -1380,16 +1380,9 @@ END;
         }
       }
     }
-	if($mobile ==  true){
-		$landsize = 16;
-	}else{
-		$landsize = 32;
-	}
-	$subsize = $landsize / 2;
-	
     print "<div id=\"islandMap\" align=\"center\"><table border=\"1\"><tr><td>\n";
     for($y = 0; $y < $init->islandSize; $y++) {
-      if($y % 2 == 0) { print "<img class=\"subchip\" src=\"land00.gif\" width=\"{$subsize}\" height=\"{$landsize}\" alt=\"{$y}\">"; }
+      if($y % 2 == 0) { print "<img class=\"subchip\" src=\"land00.gif\" alt=\"{$y}\">"; }
 
       for($x = 0; $x < $init->islandSize; $x++) {
 		$target = '';
@@ -1400,7 +1393,7 @@ END;
         $hako->landString($land[$x][$y], $landValue[$x][$y], $x, $y, $mode, $commandText, $invest, $Cname,$ctype,$target);
       }
 
-      if($y % 2 == 1) { print "<img name=\" class=\"subchip\" src=\"land00.gif\" width=\"{$subsize}\" height=\"{$landsize}\" alt=\"{$y}\">"; }
+      if($y % 2 == 1) { print "<img class=\"subchip\" src=\"land00.gif\" alt=\"{$y}\">"; }
 
       print "<br>";
     }

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -588,7 +588,7 @@ class Hako extends HakoIO {
       print "<a href=\"javascript: void(0);\" onclick=\"ps($x,$y)\">";
       $naviText = "{$comStr}\\n{$naviText}";
     }
-    print "<img class=\"mapchip\" src=\"{$image}\"width=\"32\" height=\"32\" alt=\"{$point} {$naviTitle} {$comStr}\" onMouseOver=\"Navi({$naviPos},'{$image}', '{$naviTitle}', '{$point}', '{$naviText}', {$naviExp});\">";
+    print "<img class=\"mapchip\" src=\"{$image}\" alt=\"{$point} {$naviTitle} {$comStr}\" onMouseOver=\"Navi({$naviPos},'{$image}', '{$naviTitle}', '{$point}', '{$naviText}', {$naviExp});\">";
 
     // 座標設定閉じ
     if($mode == 1 || $mode == 2)

--- a/trade/templates/banners.html
+++ b/trade/templates/banners.html
@@ -1,4 +1,4 @@
-	<div id="toyBox" style="float:left;  width:50%">
+	<div id="toyBox">
 		<div id="CommentBox">
 		<h2>コメント更新</h2>
 		<form action="{GLTH}" method="post" accept-charset="UTF-8">


### PR DESCRIPTION
### Motivation
- 既存の HTML 構造を維持しつつ、国情報一覧や開発画面の下部パネルが画面端に密着したりモバイルで崩れる問題を解消するための暫定対応を行いました。
- マップのタイル（マップチップ）の表示制御を HTML のインライン属性から CSS 側へ移管してレスポンシブ化を容易にするためです。

### Description
- `trade/css/nd_flat.css` を更新し、マップチップとサブチップのサイズ制御を CSS に統合し、グローバルメニューや一覧テーブル、下部パネルのレスポンシブスタイルを追加しました（`#islandMap td` の折り返し防止、`#TradeBox/#BalanceOut/#toyBox` の2列→1列挙動など）。
- `trade/hako-html.php` のトップの新規登録リンクを画像から通常のボタン風リンクへ置換し、開発画面下部の `TradeBox` と `BalanceOut` に付いていたインラインの `float/width` 指定を削除しました。
- `trade/hako-main.php` 内の地形出力で出力される `<img>` 要素から幅／高さのインライン属性を削除し、CSS 側でサイズを制御するように変更しました。
- `trade/templates/banners.html` の `#toyBox` に付いていた固定 float/width を除去して CSS 側へ委譲しました。

### Testing
- `git diff --check` を実行して差分の指摘はありませんでした（成功）。
- `php -l trade/hako-html.php` と `php -l trade/hako-main.php` を実行し構文チェックは通過しました（成功）。
- PHP 内蔵サーバーで `php -S 127.0.0.1:8765 -t trade` を立ち上げて `curl` で `hako-main.php` にアクセスしましたが、既存コードで `HTML::header()` 等の非 static メソッドが静的呼び出しされるため PHP 実行時に Fatal Error が発生しページ描画までは完了しませんでした（既存の互換性問題によるため今回の変更によるものではありません）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cfe8d40d08326916760ef0868c2db)