### PR TITLE
設定画面の操作ボタン上に余白を追加

### DIFF
--- a/trade/css/nd_flat-blue.css
+++ b/trade/css/nd_flat-blue.css
@@ -489,6 +489,12 @@ h2.Turn {
   max-width: 100%;
 }
 
+/* Hidden form fields sit between each setting and its action button in
+ * templates/banners.html, so they do not create any visual separation. */
+#toyBox input[type="submit"] {
+  margin-top: 8px;
+}
+
 /* SECTION: Semantic text colors
  * PHPが出力する既存クラスの色指定です。
  * ゲーム上の意味を持つ色なので、変更時は可読性と意味の対応を確認してください。

--- a/trade/css/nd_flat-grey.css
+++ b/trade/css/nd_flat-grey.css
@@ -489,6 +489,12 @@ h2.Turn {
   max-width: 100%;
 }
 
+/* Hidden form fields sit between each setting and its action button in
+ * templates/banners.html, so they do not create any visual separation. */
+#toyBox input[type="submit"] {
+  margin-top: 8px;
+}
+
 /* SECTION: Semantic text colors
  * PHPが出力する既存クラスの色指定です。
  * ゲーム上の意味を持つ色なので、変更時は可読性と意味の対応を確認してください。

--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -490,6 +490,12 @@ h2.Turn {
   max-width: 100%;
 }
 
+/* Hidden form fields sit between each setting and its action button in
+ * templates/banners.html, so they do not create any visual separation. */
+#toyBox input[type="submit"] {
+  margin-top: 8px;
+}
+
 /* SECTION: Semantic text colors
  * PHPが出力する既存クラスの色指定です。
  * ゲーム上の意味を持つ色なので、変更時は可読性と意味の対応を確認してください。


### PR DESCRIPTION
### Motivation
- 設定画面（国旗アップロード・首都名変更・リンク更新など）で操作ボタンが直前の項目に密着して表示されるため、視認性と操作性を改善する必要があった。

### Description
- `trade/css/nd_flat.css`、`trade/css/nd_flat-blue.css`、`trade/css/nd_flat-grey.css` の3ファイルを更新して、`#toyBox input[type="submit"]` に `margin-top: 8px;` を追加した。
- これにより、hidden フィールド等で視覚的な間隔が確保されないケースでも、各設定の操作ボタン上に適切な空隙が入るようになる。

### Testing
- 実行した Python スクリプトで3テーマすべてに該当ルールが1つずつ存在することと CSS の波括弧バランスを確認（成功）。
- `php -l trade/hako-html.php` による PHP 構文チェックでエラーなし（成功）。
- `git diff --check` を実行して差分上の問題がないことを確認（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65ba3e47b0832690d5cb63878192b4)