### PR TITLE
Preserve backup logs/history/statistics by copying in `backUp()`

### DIFF
--- a/trade/hako-file.php
+++ b/trade/hako-file.php
@@ -677,19 +677,19 @@ class HakoIO {
     
     mkdir("{$init->dirName}", $init->dirMode);
 
-    // ログファイルだけ戻す
+    // ログ・履歴・統計はバックアップにも残し、現役側に引き継ぐ
     for($i = 0; $i <= $init->logMax; $i++) {
       if(is_file("{$init->dirName}.bak0/hakojima.log{$i}")){
-        rename("{$init->dirName}.bak0/hakojima.log{$i}", "{$init->dirName}/hakojima.log{$i}");
+        copy("{$init->dirName}.bak0/hakojima.log{$i}", "{$init->dirName}/hakojima.log{$i}");
        }
     }
     if(is_file("{$init->dirName}.bak0/hakojima.his")){
-      rename("{$init->dirName}.bak0/hakojima.his", "{$init->dirName}/hakojima.his");
+      copy("{$init->dirName}.bak0/hakojima.his", "{$init->dirName}/hakojima.his");
     }
       
   //統計ファイルを戻す
    if(is_file("{$init->dirName}.bak0/statistic.xml")){
-      rename("{$init->dirName}.bak0/statistic.xml", "{$init->dirName}/statistic.xml");
+      copy("{$init->dirName}.bak0/statistic.xml", "{$init->dirName}/statistic.xml");
 	  }
 	}
   //---------------------------------------------------


### PR DESCRIPTION
### Motivation
- Ensure log, history and statistics files remain in the backup namespace while also being available in the active directory by avoiding destructive moves.

### Description
- In `backUp()` replace destructive `rename()` operations with `copy()` for `hakojima.log*`, `hakojima.his`, and `statistic.xml` so backups are preserved and the active directory receives copies, and update the comment to reflect this behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65f35e1ee08326b902108779c6e1a4)