### PR TITLE
新規建国時の掲示板・定期輸送データ初期化を修正

### DIFF
--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -105,13 +105,13 @@ class Make {
         'arg'    => 0,
         );
     }
-    $lbbs = "";
+    $lbbs = array();
     // 初期掲示板生成
     for($i = 0; $i < $init->lbbsMax; $i++) {
       $lbbs[$i] = "0>>0>>";
     }
 
-    $regT = "";
+    $regT = array();
     // 初期定期輸送生成
     for($i = 0; $i < $init->regTMax; $i++) {
       $regT[$i] = "";


### PR DESCRIPTION
### Motivation
- 新規建国処理で `$lbbs` と `$regT` を空文字列で初期化したままオフセット代入していたため、PHP 8 系での文字列オフセット割当てに関する警告や空文字列代入の致命的エラーが発生していた。 

### Description
- `trade/hako-turn.php` の `makeNewIsland()` にて、`$lbbs = "";` を ``$lbbs = array();`` に変更し初期掲示板データを配列として初期化した。 
- 同じく `makeNewIsland()` で `'$regT = "";'` を ``$regT = array();`` に変更し定期輸送データを配列として初期化した。 

### Testing
- 実行ファイル単体の構文チェック `php -l trade/hako-turn.php` を実行し該当ファイルに構文エラーがないことを確認した（成功）。
- 全コードベースの PHP リント `find trade -type f -name '*.php' | xargs php -l` を試行したが、今回の変更箇所とは無関係な既存ファイル `trade/tests/props_0.2/display/htmltemplate.php:186` の構文エラーにより走査は完走しなかった（未完了）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a660bbeb4848326af85a352d79b0e48)