### PR TITLE
国旗再アップロード時に画像キャッシュを更新

### DIFF
--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -494,8 +494,9 @@ if (($islandListStart != 1) || ($islandListSentinel != $hako->islandNumber)) {
 		}
 		$owner =  "<br>{$init->tagTH_}元首：{$owner}{$init->_tagTH}";
 		$bannerad = "img/up/log";
-		if (preg_match('/^[A-Za-z0-9_-]+$/', $banum) && file_exists($bannerad.'/'.$banum.'.png')){
-			$bannerad = 'up/log/'.$banum.'.png';
+		$bannerPath = $bannerad.'/'.$banum.'.png';
+		if (preg_match('/^[A-Za-z0-9_-]+$/', $banum) && file_exists($bannerPath)){
+			$bannerad = 'up/log/'.$banum.'.png?v='.filemtime($bannerPath);
 			$bannerad = "<IMG SRC=\"{$bannerad}\" width=\"45\" height=\"30\"align=\"left\" title=\"{$pname}旗\" ALT=\"{$pname}旗\">";
 		}else{
 			$bannerad = "";
@@ -1185,8 +1186,9 @@ END;
 	$socad .="<IMG SRC=\"socsec.png\" width=\"20\" height=\"20\" title=\"社会保障指数：{$soclv}\" ALT=\"社会保障指数：{$soclv}\"> {$soclv}";
 
 	$bannerad = "img/up/log";
-	if (preg_match('/^[A-Za-z0-9_-]+$/', $banum) && file_exists($bannerad.'/'.$banum.'.png')){
-		$bannerad = 'up/log/'.$banum.'.png';
+	$bannerPath = $bannerad.'/'.$banum.'.png';
+	if (preg_match('/^[A-Za-z0-9_-]+$/', $banum) && file_exists($bannerPath)){
+		$bannerad = 'up/log/'.$banum.'.png?v='.filemtime($bannerPath);
 		$bannerad = "<IMG align = \"center\" SRC=\"{$bannerad}\" width=\"45\" height=\"30\"align=\"left\" title=\"{$pname}旗\" ALT=\"{$pname}旗\">";
 	}else{
 		$bannerad = "";

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -504,6 +504,7 @@ class Make {
     }
 
     $savePath = $uploadDir . '/' . $flagId . '.png';
+    $previousMtime = file_exists($savePath) ? filemtime($savePath) : 0;
     if(!imagepng($dst, $savePath)) {
       imagedestroy($src);
       imagedestroy($dst);
@@ -511,6 +512,11 @@ class Make {
       return;
     }
     chmod($savePath, 0604);
+    // The file name is reused on subsequent uploads, so give every saved
+    // version a distinct mtime for the cache-busting URL used by the views.
+    $cacheMtime = max(time(), $previousMtime + 1);
+    touch($savePath, $cacheMtime);
+    clearstatcache(true, $savePath);
     imagedestroy($src);
     imagedestroy($dst);
 


### PR DESCRIPTION
### Motivation
- 国旗ファイル（`bn-*.png`）を同じファイル名で再アップロードした際にブラウザが古い画像をキャッシュしてしまい、新しい画像がすぐに反映されない問題を解消するための変更です。

### Description
- 保存処理側で既存ファイルの変更時刻を取得し、新しい保存時にその更新時刻を単調増加させるために `filemtime` を参照して `touch` を呼ぶようにしました（`trade/hako-turn.php` に `previousMtime` の取得と `touch(..., max(time(), previous+1))`、および `clearstatcache` を追加）。
- 表示側で国旗画像の URL にファイル更新時刻をクエリパラメータとして付与するようにし、ブラウザのキャッシュを回避するようにしました（`trade/hako-html.php` の該当箇所で `...?v=` に `filemtime` を付加）。
- 表示処理は国一覧と国詳細の両方に適用しています（同様のテンプレート内の2箇所を更新）。

### Testing
- `php -l trade/hako-turn.php` を実行して構文チェックが成功しました（合格）。
- `php -l trade/hako-html.php` を実行して構文チェックが成功しました（合格）。
- `git diff --check` 相当のチェックを実行して問題がないことを確認しました（合格）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6611e915d08326a573e739dd15c8ec)