### PR TITLE
Render island settings in owner view and simplify change forms/logic

### DIFF
--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -635,12 +635,7 @@ END;
   // 国の登録と設定
   //---------------------------------------------------
   function regist(&$hako, $data = "") {
-    global $init;
-    $this->changeIslandInfo($hako->islandList);
-    $this->changeOwnerName($hako->islandList);
-	$this->freezeNation($hako->islandList);
-    $this->setStyleSheet();
-    $this->setLocalImage($data);
+    $this->freezeNation($hako->islandList);
   }
   //---------------------------------------------------
   // 新しい国を探す
@@ -690,28 +685,22 @@ END;
   //---------------------------------------------------
   // 国の名前とパスワードの変更
   //---------------------------------------------------
-  function changeIslandInfo($islandList = "") {
-    global $init;
+  function changeIslandInfo($island, $password) {
+    $password = htmlspecialchars($password, ENT_QUOTES);
     print <<<END
 <div id="ChangeInfo">
 <h2>国の名前とパスワードの変更</h2>
 <p>
 (注意)名前の変更には500億Vaかかります。
 </p>
-<form action="{$GLOBALS['THIS_FILE']}" method="post" accept-charset=”UTF-8″>
-どの国ですか？<br>
-<select NAME="ISLANDID">
-$islandList
-</select>
-<br>
+<form action="{$GLOBALS['THIS_FILE']}" method="post" accept-charset="UTF-8">
+対象国：{$island['name']}<br>
 どんな名前に変えますか？(変更する場合のみ)<br>
 <input type="text" name="ISLANDNAME" size="32" maxlength="32"><br>
-パスワードは？(必須)<br>
-<input type="password" name="OLDPASS" size="32" maxlength="32"><br>
 新しいパスワードは？(変更する時のみ)<br>
 <input type="password" name="PASSWORD" size="32" maxlength="32"><br>
-念のためパスワードをもう一回(変更する時のみ)<br>
-<input type="password" name="PASSWORD2" size="32" maxlength="32"><br>
+<input type="hidden" name="ISLANDID" value="{$island['id']}">
+<input type="hidden" name="OLDPASS" value="{$password}">
 <input type="hidden" name="mode" value="change">
 <input type="submit" value="変更する">
 </form>
@@ -723,21 +712,17 @@ END;
   //---------------------------------------------------
   // オーナー名の変更
   //---------------------------------------------------
-  function changeOwnerName($islandList = "") {
-    global $init;
+  function changeOwnerName($island, $password) {
+    $password = htmlspecialchars($password, ENT_QUOTES);
     print <<<END
 <div id="ChangeOwnerName">
 <h2>オーナー名の変更</h2>
-<form action="{$GLOBALS['THIS_FILE']}" method="post" accept-charset=”UTF-8″>
-どの国ですか？<br>
-<select name="ISLANDID">
-{$islandList}
-</select>
-<br>
+<form action="{$GLOBALS['THIS_FILE']}" method="post" accept-charset="UTF-8">
+対象国：{$island['name']}<br>
 新しいオーナー名は？<br>
 <input type="text" name="OWNERNAME" size="32" maxlength="32"><br>
-パスワードは？<br>
-<input type="password" name="OLDPASS" size="32" maxlength="32"><br>
+<input type="hidden" name="ISLANDID" value="{$island['id']}">
+<input type="hidden" name="OLDPASS" value="{$password}">
 <input type="hidden" name="mode" value="ChangeOwnerName">
 <input type="submit" value="変更する">
 </form>
@@ -971,6 +956,14 @@ class HtmlMap extends HTML {
       print "<div id=\"BalanceOut\">\n";
 	  $this->BalanceOutput($hako,$island);
       print "</div>\n";
+
+    // 国ごとの設定と表示設定は、収支レポートの下に表示する。
+    print "<hr style=\"clear:both;\">\n";
+    $settings = new HtmlTop;
+    $settings->changeIslandInfo($island, $data['PASSWORD']);
+    $settings->changeOwnerName($island, $data['PASSWORD']);
+    $settings->setStyleSheet();
+    $settings->setLocalImage($data);
 
     if($init->useBbs) {
       print "<hr style=\"clear:both;\">\n<div id=\"localBBS\">\n";

--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -800,6 +800,7 @@ class Make {
     $num = $hako->idToNumber[$id];
     $island = $hako->islands[$num];
     $name = $island['name'];
+    $flag = 0;
 
     // パスワードチェック
     if(strcmp($data['OLDPASS'], $init->specialPassword) == 0) {
@@ -807,13 +808,6 @@ class Make {
       //$island['money'] = $init->maxMoney;
       //$island['food']  = $init->maxFood;
     } elseif(!Util::checkPassword($island['password'], $data['OLDPASS'])) {
-      // password間違い
-      HakoError::wrongPassword();
-      return;
-    }
-
-    // 確認用パスワード
-    if(strcmp($data['PASSWORD'], $data['PASSWORD2']) != 0) {
       // password間違い
       HakoError::wrongPassword();
       return;
@@ -856,7 +850,7 @@ class Make {
       $flag = 1;
     }
 
-    if(($flag == 0) && (strcmp($data['PASSWORD'], $data['PASSWORD2']) != 0)) {
+    if($flag == 0) {
       // どちらも変更されていない
       HakoError::changeNothing();
       return;


### PR DESCRIPTION
### Motivation

- Move per-island configuration (change name/password/owner and local display settings) into the island owner view so forms are island-specific and no longer require a manual island selection.
- Simplify the information-change flow and remove redundant password confirmation fields from the UI and server logic.

### Description

- Removed calls to `changeIslandInfo`, `changeOwnerName`, `setStyleSheet`, and `setLocalImage` from `regist()` so registration no longer renders those global controls.
- Reworked `changeIslandInfo` and `changeOwnerName` signatures to `changeIslandInfo($island, $password)` and `changeOwnerName($island, $password)`, switched from a select list to showing the current island (`{$island['name']}`) and added hidden `ISLANDID` and `OLDPASS` fields; `OLDPASS` is sanitized with `htmlspecialchars` and `accept-charset` attributes were normalized.
- In the map/owner renderer, added a settings block after the balance report that instantiates `HtmlTop` and calls `changeIslandInfo($island, $data['PASSWORD'])`, `changeOwnerName($island, $data['PASSWORD'])`, `setStyleSheet()`, and `setLocalImage($data)` so the settings are displayed per-island.
- Simplified `changeMain()` in `trade/hako-turn.php` by initializing `$flag = 0`, removing the now-obsolete password-confirmation check, and using `if ($flag == 0)` to detect a no-op change and return the appropriate error.

### Testing

- Ran PHP syntax checks on the modified files with `php -l`, which passed.
- Performed an automated smoke check of the owner page rendering to confirm the settings forms appear and submit-related endpoints are reachable, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6614393224832691ed845f928d5dbd)