### PR TITLE
Set font-size and line-height for #NaviView in flat themes

### DIFF
--- a/trade/css/nd_flat-blue.css
+++ b/trade/css/nd_flat-blue.css
@@ -452,6 +452,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 251, 255, 0.96);
   border: 1px solid var(--nd-color-border-strong);

--- a/trade/css/nd_flat-grey.css
+++ b/trade/css/nd_flat-grey.css
@@ -452,6 +452,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 250, 252, 0.96);
   border: 1px solid var(--nd-color-border-strong);

--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -453,6 +453,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(255, 250, 245, 0.96);
   border: 1px solid var(--nd-color-border-strong);


### PR DESCRIPTION
### Motivation
- Ensure the island map navigation popup text is readable because `#islandMap td` uses zero-sized text to remove gaps between map chips.

### Description
- Added a clarifying comment and set `font-size: 14px;` and `line-height: 1.5;` on `#NaviView` in `trade/css/nd_flat.css`, `trade/css/nd_flat-blue.css`, and `trade/css/nd_flat-grey.css` to restore readable text sizing for the popup.

### Testing
- No automated tests were run for this small presentational change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66626feeb08326a8ee4edd731ac95c)