### PR TITLE
Improve map navigation popup layout and spacing across flat themes

### DIFF
--- a/trade/css/nd_flat-blue.css
+++ b/trade/css/nd_flat-blue.css
@@ -452,6 +452,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 251, 255, 0.96);
   border: 1px solid var(--nd-color-border-strong);
@@ -468,11 +471,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map

--- a/trade/css/nd_flat-grey.css
+++ b/trade/css/nd_flat-grey.css
@@ -452,6 +452,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 250, 252, 0.96);
   border: 1px solid var(--nd-color-border-strong);
@@ -468,11 +471,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map

--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -453,6 +453,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(255, 250, 245, 0.96);
   border: 1px solid var(--nd-color-border-strong);
@@ -469,11 +472,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map


### PR DESCRIPTION
### Motivation

- Fix layout and spacing issues in the island map mouse-over popup so the thumbnail and text align correctly and the popup text is readable despite zero-sized map TDs.

### Description

- Added `font-size: 14px` and `line-height: 1.5` to `#NaviView` to restore readable text flow inside the popup. 
- Floated `.NaviImg` left and increased `.NaviText` left margin from `15px` to `52px` so the image and text sit side-by-side without overlap. 
- Introduced a sibling rule `.NaviImg + .NaviText { padding-top: 6px; }` to vertically align the text with the thumbnail. 
- Applied the same changes to `trade/css/nd_flat.css`, `trade/css/nd_flat-blue.css`, and `trade/css/nd_flat-grey.css` for consistent behavior across themes.

### Testing

- Ran `stylelint` against the modified CSS files and it reported no errors. 
- Executed the project build (`npm run build`) in CI and the build completed successfully. 
- CSS changes were picked up in automated visual snapshot tests in CI and no regressions were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66626feeb08326a8ee4edd731ac95c)