### PR TITLE
Improve Navi popup layout and avoid empty `naviText` newline

### DIFF
--- a/trade/css/nd_flat-blue.css
+++ b/trade/css/nd_flat-blue.css
@@ -452,6 +452,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 251, 255, 0.96);
   border: 1px solid var(--nd-color-border-strong);
@@ -468,11 +471,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map

--- a/trade/css/nd_flat-grey.css
+++ b/trade/css/nd_flat-grey.css
@@ -452,6 +452,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 250, 252, 0.96);
   border: 1px solid var(--nd-color-border-strong);
@@ -468,11 +471,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map

--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -453,6 +453,9 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(255, 250, 245, 0.96);
   border: 1px solid var(--nd-color-border-strong);
@@ -469,11 +472,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map

--- a/trade/hako-edit.php
+++ b/trade/hako-edit.php
@@ -80,6 +80,7 @@ class Hako extends HakoIO {
     global $init;
     $point = "({$x},{$y})";
     $naviExp = "''";
+    $naviText = "";
 
     if($x < $init->islandSize / 2)
       $naviPos = 0;
@@ -538,7 +539,9 @@ class Hako extends HakoIO {
 
     if($mode == 1 || $mode == 2) {
       print "<a href=\"javascript: void(0);\" onclick=\"ps($x,$y)\">";
-      $naviText = "{$comStr}\\n{$naviText}";
+      if($comStr !== '') {
+        $naviText = "{$comStr}\\n{$naviText}";
+      }
     }
     print "<img class=\"mapchip\" src=\"{$image}\" alt=\"{$point} {$naviTitle} {$comStr}\" onMouseOver=\"Navi({$naviPos},'{$image}', '{$naviTitle}', '{$point}', '{$naviText}', {$naviExp});\" onMouseOut=\"NaviClose(); return false\">";
 

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -586,7 +586,9 @@ class Hako extends HakoIO {
 
     if($mode == 1 || $mode == 2) {
       print "<a href=\"javascript: void(0);\" onclick=\"ps($x,$y)\">";
-      $naviText = "{$comStr}\\n{$naviText}";
+      if($comStr !== '') {
+        $naviText = "{$comStr}\\n{$naviText}";
+      }
     }
     print "<img class=\"mapchip\" src=\"{$image}\" alt=\"{$point} {$naviTitle} {$comStr}\" onMouseOver=\"Navi({$naviPos},'{$image}', '{$naviTitle}', '{$point}', '{$naviText}', {$naviExp});\">";
 


### PR DESCRIPTION
### Motivation
- Fix visual misalignment and spacing in the island map navigation popup so the image and text align correctly across themes.  
- Prevent a stray leading newline and potential undefined variable use when building the navigation text (`naviText`) if no comment string is present.

### Description
- Adjusted `#NaviView` in `nd_flat.css`, `nd_flat-blue.css`, and `nd_flat-grey.css` to set `font-size: 14px` and `line-height: 1.5` for readable popup text.  
- Updated popup layout by adding `float: left` to `.NaviImg`, increasing `.NaviText` `margin-left` to `52px`, and adding `.NaviImg + .NaviText { padding-top: 6px; }` to align text next to images.  
- In `trade/hako-edit.php` and `trade/hako-main.php` initialized `naviText` and changed concatenation to only prepend `comStr` when it is non-empty (`if($comStr !== '') { $naviText = "{$comStr}\n{$naviText}"; }`) to avoid leading newlines and undefined text.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66626feeb08326a8ee4edd731ac95c)