### PR TITLE
Adjust Navi popup layout and avoid empty tooltip newline

### DIFF
--- a/trade/css/nd_flat-blue.css
+++ b/trade/css/nd_flat-blue.css
@@ -452,12 +452,21 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 251, 255, 0.96);
   border: 1px solid var(--nd-color-border-strong);
   border-radius: var(--nd-radius-md);
   box-shadow: var(--nd-shadow-md);
   text-align: left;
+}
+
+#NaviView::after {
+  display: block;
+  clear: both;
+  content: "";
 }
 
 #NaviTitle {
@@ -468,11 +477,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map
@@ -942,6 +956,15 @@ div.tooltip span {
   #islandMap table {
     width: 370px;
     height: 370px;
+  }
+
+  #NaviView {
+    position: static;
+    box-sizing: border-box;
+    width: calc(100vw - 16px);
+    min-width: 0;
+    max-width: 100%;
+    margin: 8px auto 0;
   }
 
   #IslandView {

--- a/trade/css/nd_flat-grey.css
+++ b/trade/css/nd_flat-grey.css
@@ -452,12 +452,21 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(248, 250, 252, 0.96);
   border: 1px solid var(--nd-color-border-strong);
   border-radius: var(--nd-radius-md);
   box-shadow: var(--nd-shadow-md);
   text-align: left;
+}
+
+#NaviView::after {
+  display: block;
+  clear: both;
+  content: "";
 }
 
 #NaviTitle {
@@ -468,11 +477,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map
@@ -942,6 +956,15 @@ div.tooltip span {
   #islandMap table {
     width: 370px;
     height: 370px;
+  }
+
+  #NaviView {
+    position: static;
+    box-sizing: border-box;
+    width: calc(100vw - 16px);
+    min-width: 0;
+    max-width: 100%;
+    margin: 8px auto 0;
   }
 
   #IslandView {

--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -453,12 +453,21 @@ h2.Turn {
   min-width: 310px;
   width: auto;
   padding: 10px;
+  /* #islandMap td uses zero-sized text to remove gaps between map chips. */
+  font-size: 14px;
+  line-height: 1.5;
   color: var(--nd-color-text);
   background: rgba(255, 250, 245, 0.96);
   border: 1px solid var(--nd-color-border-strong);
   border-radius: var(--nd-radius-md);
   box-shadow: var(--nd-shadow-md);
   text-align: left;
+}
+
+#NaviView::after {
+  display: block;
+  clear: both;
+  content: "";
 }
 
 #NaviTitle {
@@ -469,11 +478,16 @@ h2.Turn {
 }
 
 .NaviImg {
+  float: left;
   margin: 6px;
 }
 
 .NaviText {
-  margin-left: 15px;
+  margin-left: 52px;
+}
+
+.NaviImg + .NaviText {
+  padding-top: 6px;
 }
 
 /* SECTION: Island map
@@ -943,6 +957,15 @@ div.tooltip span {
   #islandMap table {
     width: 370px;
     height: 370px;
+  }
+
+  #NaviView {
+    position: static;
+    box-sizing: border-box;
+    width: calc(100vw - 16px);
+    min-width: 0;
+    max-width: 100%;
+    margin: 8px auto 0;
   }
 
   #IslandView {

--- a/trade/hako-edit.php
+++ b/trade/hako-edit.php
@@ -80,6 +80,7 @@ class Hako extends HakoIO {
     global $init;
     $point = "({$x},{$y})";
     $naviExp = "''";
+    $naviText = "";
 
     if($x < $init->islandSize / 2)
       $naviPos = 0;
@@ -538,7 +539,9 @@ class Hako extends HakoIO {
 
     if($mode == 1 || $mode == 2) {
       print "<a href=\"javascript: void(0);\" onclick=\"ps($x,$y)\">";
-      $naviText = "{$comStr}\\n{$naviText}";
+      if($comStr !== '') {
+        $naviText = "{$comStr}\\n{$naviText}";
+      }
     }
     print "<img class=\"mapchip\" src=\"{$image}\" alt=\"{$point} {$naviTitle} {$comStr}\" onMouseOver=\"Navi({$naviPos},'{$image}', '{$naviTitle}', '{$point}', '{$naviText}', {$naviExp});\" onMouseOut=\"NaviClose(); return false\">";
 

--- a/trade/hako-main.php
+++ b/trade/hako-main.php
@@ -586,7 +586,9 @@ class Hako extends HakoIO {
 
     if($mode == 1 || $mode == 2) {
       print "<a href=\"javascript: void(0);\" onclick=\"ps($x,$y)\">";
-      $naviText = "{$comStr}\\n{$naviText}";
+      if($comStr !== '') {
+        $naviText = "{$comStr}\\n{$naviText}";
+      }
     }
     print "<img class=\"mapchip\" src=\"{$image}\" alt=\"{$point} {$naviTitle} {$comStr}\" onMouseOver=\"Navi({$naviPos},'{$image}', '{$naviTitle}', '{$point}', '{$naviText}', {$naviExp});\">";
 


### PR DESCRIPTION
### Motivation
- Improve the layout and spacing of the island map navigation popup so images and text align and wrap properly. 
- Prevent a leading blank line in the tooltip text when the comment string is empty. 
- Make the navigation popup behave and size correctly on narrow/mobile viewports.

### Description
- Updated `#NaviView` styles in `trade/css/nd_flat.css`, `trade/css/nd_flat-blue.css`, and `trade/css/nd_flat-grey.css` to set `font-size` and `line-height`, add a clearfix (`#NaviView::after`), and adjust text/image flow with `.NaviImg { float: left; }`, `.NaviText { margin-left: 52px; }`, and `.NaviImg + .NaviText { padding-top: 6px; }`.
- Added a responsive mobile block for `#NaviView` to switch to `position: static`, constrain width with `width: calc(100vw - 16px)`, and apply `box-sizing: border-box` for proper sizing on small viewports.
- In `trade/hako-edit.php` and `trade/hako-main.php` initialized `$naviText` and changed how tooltip text is composed so `comStr` is prepended only when non-empty (`if($comStr !== '') { $naviText = "{$comStr}\n{$naviText}"; }`) to avoid creating a leading newline in the tooltip.

### Testing
- Ran PHP syntax checks with `php -l` on `trade/hako-edit.php` and `trade/hako-main.php`, which reported no syntax errors.
- Linted the modified CSS files with `stylelint`/`csslint` (project linter), and the files passed the configured checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66626feeb08326a8ee4edd731ac95c)