### PR TITLE
Fix RSS item dates on modern PHP

### DIFF
--- a/trade/feedcreator/include/feedcreator.class.php
+++ b/trade/feedcreator/include/feedcreator.class.php
@@ -850,6 +850,16 @@ class FeedDate {
 	var $unix;
 	
 	/**
+	 * PHP 5+ constructor.
+	 *
+	 * The method named after the class below is retained for compatibility with
+	 * applications that may call it directly.
+	 */
+	function __construct($dateString="") {
+		$this->FeedDate($dateString);
+	}
+
+	/**
 	 * Creates a new instance of FeedDate representing a given date.
 	 * Accepts RFC 822, ISO 8601 date formats as well as unix time stamps.
 	 * @param mixed $dateString optional the date this FeedDate will represent. If not specified, the current date and time is used.


### PR DESCRIPTION
### Motivation

- The `FeedDate` class only implemented the old PHP4-style constructor `FeedDate()`, so on PHP 5+/8+ the class-name method is not treated as a constructor and the `$unix` field was left uninitialized.
- Because of that, `new FeedDate($this->items[$i]->date)` produced a null/uninitialized timestamp and feed generation time was used for each item, causing all RSS/Atom items to show the same date.
- The change aims to ensure each `FeedItem` keeps its supplied publication date when running on modern PHP versions.

### Description

- Added a PHP 5+ constructor `__construct($dateString="")` to `trade/feedcreator/include/feedcreator.class.php` that delegates to the existing `FeedDate($dateString)` initializer to preserve backward compatibility.
- This ensures `new FeedDate($date)` correctly initializes the internal timestamp (`$unix`) under modern PHP while keeping the original parsing logic intact.
- The change was committed to the repository (commit `2b75c4c`).

### Testing

- Ran syntax check with `php -l trade/feedcreator/include/feedcreator.class.php`, which passed successfully.
- Performed a regression check with `php -r 'require "trade/feedcreator/include/feedcreator.class.php"; ...'` that constructed two `FeedDate` instances from different ISO8601 timestamps and verified they produce distinct `iso8601()` outputs, which succeeded.
- Ran `git diff --check` and confirmed no whitespace or diff issues and that the working tree is clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a674058d9088326a26f82a30abc1ca1)