### PR TITLE
Limit NewsBox input width and adjust banners template for responsive news field

### DIFF
--- a/trade/css/nd_flat-blue.css
+++ b/trade/css/nd_flat-blue.css
@@ -571,6 +571,22 @@ h2.Turn {
   max-width: 100%;
 }
 
+/* ニュース本文は40文字に見合う幅を上限とし、狭い画面でははみ出さないようにします。 */
+#NewsBox table {
+  width: 100%;
+}
+
+#NewsBox .news-content-field {
+  width: 100%;
+}
+
+#NewsBox #news_text {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 40em;
+  min-width: 0;
+}
+
 /* Hidden form fields sit between each setting and its action button in
  * templates/banners.html, so they do not create any visual separation. */
 #toyBox input[type="submit"] {

--- a/trade/css/nd_flat-grey.css
+++ b/trade/css/nd_flat-grey.css
@@ -571,6 +571,22 @@ h2.Turn {
   max-width: 100%;
 }
 
+/* ニュース本文は40文字に見合う幅を上限とし、狭い画面でははみ出さないようにします。 */
+#NewsBox table {
+  width: 100%;
+}
+
+#NewsBox .news-content-field {
+  width: 100%;
+}
+
+#NewsBox #news_text {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 40em;
+  min-width: 0;
+}
+
 /* Hidden form fields sit between each setting and its action button in
  * templates/banners.html, so they do not create any visual separation. */
 #toyBox input[type="submit"] {

--- a/trade/css/nd_flat.css
+++ b/trade/css/nd_flat.css
@@ -572,6 +572,22 @@ h2.Turn {
   max-width: 100%;
 }
 
+/* ニュース本文は40文字に見合う幅を上限とし、狭い画面でははみ出さないようにします。 */
+#NewsBox table {
+  width: 100%;
+}
+
+#NewsBox .news-content-field {
+  width: 100%;
+}
+
+#NewsBox #news_text {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 40em;
+  min-width: 0;
+}
+
 /* Hidden form fields sit between each setting and its action button in
  * templates/banners.html, so they do not create any visual separation. */
 #toyBox input[type="submit"] {

--- a/trade/templates/banners.html
+++ b/trade/templates/banners.html
@@ -29,7 +29,7 @@
 		<tr><td>
 		<label for="TEXT2">発表者</label></td>
 		<td><input type="text" name="TEXT2" maxlength="10" value="{news_by}"><br />最大10文字</td></tr>
-		<tr><td><label for="TEXT">報道内容</label></td><td><input type="text" name="TEXT" maxlength="40" class="limited" value="{news}" id='news_text'><br />残り<span id="charsLeft2">40</span>文字</td></tr>
+		<tr><td><label for="news_text">報道内容</label></td><td class="news-content-field"><input type="text" name="TEXT" maxlength="40" class="limited" value="{news}" id="news_text"><br />残り<span id="charsLeft2">40</span>文字</td></tr>
 		</table>
 		<p>残り投稿回数：{news_point}回</span></p>
 		<input type="hidden" name="PASSWORD" value="{PAS}">


### PR DESCRIPTION
### Motivation
- Prevent the news input from breaking narrow layouts by capping its rendered width to match the 40-character `maxlength` and ensuring it can shrink on small screens.

### Description
- Add responsive rules to `trade/css/nd_flat.css`, `trade/css/nd_flat-blue.css`, and `trade/css/nd_flat-grey.css` introducing `#NewsBox table`, `.news-content-field`, and `#News_text` (styled as `#news_text`) with `box-sizing: border-box`, `width: 100%`, `max-width: 40em`, and `min-width: 0` to limit and contain the news input.
- Update `trade/templates/banners.html` to set the news input cell to `class="news-content-field"`, make the label point to `for="news_text"`, and normalize the input `id` attribute to `id="news_text"` while keeping the `maxlength="40"` and the same UI text and counters.

### Testing
- No automated tests were run for these UI/CSS/HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b719602a88326850ac8dad381cba0)