### PR TITLE
収支レポートのグラフ読み込み競合を修正

### DIFF
--- a/trade/hako-html.php
+++ b/trade/hako-html.php
@@ -852,15 +852,15 @@ END;
   $nest_html = Util::MakeNest($nest_rep,$island['name']);
   $nest_dat = Util::MakeNest2($nest_rep);
   echo "<script>\n";
-  echo "var data = [];\n";
+  echo "window.balanceReportData = [];\n";
   foreach($nest_dat as $nest_item){
   print <<<END
-  var item{$j} = google.visualization.arrayToDataTable([
+  var item{$j} = [
   ['','{$init->accountName['1000'][1]}', '{$init->accountName['2000'][1]}', '{$init->accountName['3000'][1]}', '{$init->accountName['4000'][1]}', '{$init->accountName['6000'][1]}',
   '{$init->accountName['7000'][1]}', '{$init->accountName['9000'][1]}','{$init->accountName['9998'][1]}','{$init->accountName['9999'][1]}', { role: 'annotation' } ],
-  ['支出', , , , ,{$nest_item[4]},{$nest_item[5]},{$nest_item[6]}, ,{$nest_item[8]},''],
-  ['収入',{$nest_item[0]} ,{$nest_item[1]} ,{$nest_item[2]} ,{$nest_item[3]}, , , ,{$nest_item[7]}, ,'']]);\n
-  data.push(item{$j});\n
+  ['支出', null, null, null, null,{$nest_item[4]},{$nest_item[5]},{$nest_item[6]}, null,{$nest_item[8]},''],
+  ['収入',{$nest_item[0]} ,{$nest_item[1]} ,{$nest_item[2]} ,{$nest_item[3]}, null, null, null,{$nest_item[7]}, null,'']];\n
+  window.balanceReportData.push(item{$j});\n
 END;
   $j++;
   }
@@ -1552,15 +1552,15 @@ END;
    $nest_dat = Util::MakeNest2($nest_rep);
    echo $nest_html;
    echo "<script>\n";
-   echo "var data = [];\n";
+   echo "window.balanceReportData = [];\n";
    foreach($nest_dat as $nest_item){
    print <<<END
-   var item{$j} = google.visualization.arrayToDataTable([
+   var item{$j} = [
    ['','{$init->accountName['1000'][1]}', '{$init->accountName['2000'][1]}', '{$init->accountName['3000'][1]}', '{$init->accountName['4000'][1]}', '{$init->accountName['6000'][1]}',
    '{$init->accountName['7000'][1]}', '{$init->accountName['9000'][1]}','{$init->accountName['9998'][1]}','{$init->accountName['9999'][1]}', { role: 'annotation' } ],
-   ['支出', , , , ,{$nest_item[4]},{$nest_item[5]},{$nest_item[6]}, ,{$nest_item[8]},''],
-   ['収入',{$nest_item[0]} ,{$nest_item[1]} ,{$nest_item[2]} ,{$nest_item[3]}, , , ,{$nest_item[7]}, ,'']]);\n
-   data.push(item{$j});\n
+   ['支出', null, null, null, null,{$nest_item[4]},{$nest_item[5]},{$nest_item[6]}, null,{$nest_item[8]},''],
+   ['収入',{$nest_item[0]} ,{$nest_item[1]} ,{$nest_item[2]} ,{$nest_item[3]}, null, null, null,{$nest_item[7]}, null,'']];\n
+   window.balanceReportData.push(item{$j});\n
 END;
 	$j++;
 	}

--- a/trade/hako.js
+++ b/trade/hako.js
@@ -122,7 +122,7 @@ $(function(){
 	$('#wstattable').visualize({type: 'line',width: '700px', title: '人口統計',colFilter: ':lt(4)',parseDirection: 'y'});
 
 	$('.show_table').click(function(){
-	var num = this.id;
+	var num = Number(this.id);
 	var options = {
 	    title: '収支レポート',
 	    width: 300,
@@ -132,8 +132,22 @@ $(function(){
 	    isStacked: true
 	};
 	
-	var chart = new google.visualization.ColumnChart(document.getElementById('show_graph'));
-	chart.draw(data[num], options);
+	var drawChart = function() {
+		if (!window.balanceReportData || !window.balanceReportData[num]) {
+			return;
+		}
+
+		var data = google.visualization.arrayToDataTable(window.balanceReportData[num]);
+		var chart = new google.visualization.ColumnChart(document.getElementById('show_graph'));
+		chart.draw(data, options);
+	};
+
+	// Google Charts のパッケージ読み込みは非同期のため、完了後に描画する。
+	if (google.visualization && google.visualization.ColumnChart) {
+		drawChart();
+	} else {
+		google.charts.setOnLoadCallback(drawChart);
+	}
 	});
 
 

--- a/trade/templates/head.html
+++ b/trade/templates/head.html
@@ -23,7 +23,7 @@
 	</script>
 
 	<script type="text/javascript" src="{baseDir}/jquery.li-scroller.1.0.js"></script>
-	<script type="text/javascript" src="{baseDir}/hako.js?v=20260726"></script>
+	<script type="text/javascript" src="{baseDir}/hako.js?v=20260730"></script>
 	<script type="text/javascript" src="{baseDir}/jquery.flot.js"></script>
 	<!--[if IE]><script type="text/javascript" src="{baseDir}/excanvas.js"></script><![endif]-->
 	<script type="text/javascript" src="{baseDir}/visualize.jQuery.js"></script>


### PR DESCRIPTION
### Motivation
- 開発画面の収支レポートが表示されない原因は、ページ生成中に`google.visualization.arrayToDataTable()`を呼び出していてCharts APIの非同期読み込みと競合していたためです。

### Description
- `trade/hako-html.php`でグラフ用のDataTableを即時生成せず、生配列を`window.balanceReportData`として出力するよう変更し、欠損値を`null`で明示しました.
- `trade/hako.js`でクリック時に生配列を`google.visualization.arrayToDataTable()`に変換して描画する`drawChart`を導入し、Charts APIが未ロードの場合は`google.charts.setOnLoadCallback()`で描画を遅延させるようにしました（IDは数値化して扱います）。
- `trade/templates/head.html`で`hako.js`のバージョンを更新してキャッシュをクリアする仕組みを追加しました（`v=20260726`→`v=20260730`）。

### Testing
- `git diff --check`を実行して差分に問題がないことを確認し成功しました。 
- `php -l trade/hako-html.php`でPHP構文チェックを実行してエラーなしを確認しました。 
- `node --check trade/hako.js`でJS構文チェックを実行してエラーなしを確認しました. 
- 変更をコミット後に`git status --short --branch`で作業ツリーがクリーンであることを確認しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b785710748326bed349d540afebd6)