### PR TITLE
Fix wide-area damage so terrain changes persist

### DIFF
--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -5891,7 +5891,7 @@ class Turn {
   //---------------------------------------------------
   // 広域被害ルーチン
   //---------------------------------------------------
-  function wideDamage($id, $name, $land, $landValue, $x, $y) {
+  function wideDamage($id, $name, &$land, &$landValue, $x, $y) {
     global $init;
 
     for($i = 0; $i < 19; $i++) {
@@ -5972,7 +5972,7 @@ class Turn {
   //---------------------------------------------------
   // 広域被害ルーチン2
   //---------------------------------------------------
-  function oilwideDamage($id, $name, $land, $landValue, $x, $y) {
+  function oilwideDamage($id, $name, &$land, &$landValue, $x, $y) {
     global $init;
 
     for($i = 0; $i < 7; $i++) {


### PR DESCRIPTION
### Motivation
- Meteor and related wide-area damage routines modified terrain in local copies of the map arrays, so logs showed damage but the island map (`$land`/`$landValue`) was not updated.
- The intent is to have wide-area effects (meteors, oil damage) actually change the map cells so the state persists after the turn.

### Description
- Changed the function signatures of `wideDamage` and `oilwideDamage` in `trade/hako-turn.php` to accept the terrain arrays by reference (`&$land`, `&$landValue`) so modifications inside the routines update the caller's arrays.
- No other logic in the damage routines was altered, only the parameter passing to ensure changes to water/ waste/ shallow-sea states are applied to the island map.

### Testing
- Ran `php -l trade/hako-turn.php` which reported no syntax errors and succeeded.
- Attempted to create the PR with `gh pr create`, but the action failed due to GitHub CLI not being authenticated in the environment (`gh auth login` / `GH_TOKEN` required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7318e4fab083269b57df1ce2af176f)