### PR TITLE
Cancel troop dispatch when target country is missing

### DIFF
--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -3648,17 +3648,17 @@ class Turn {
 		break;
 	  }
       // ターゲット取得
-      $tn = $hako->idToNumber[$target];
-      $tIsland = $hako->islands[$tn];
-      $tName = $tIsland['name'];
-
-      if($tn != 0 && empty($tn)) {
+      if(!isset($hako->idToNumber[$target])) {
         // ターゲットがすでにない
         $this->log->msNoTarget($id, $name, $comName);
 
         $returnMode = 0;
         break;
       }
+
+      $tn = $hako->idToNumber[$target];
+      $tIsland = $hako->islands[$tn];
+      $tName = $tIsland['name'];
 
       if(($hako->islandTurn - $island['starturn']) < $init->noMissile ||
 	  ($island['pop'] < $init->limitpop)) {


### PR DESCRIPTION
### Motivation
- Prevent resolving a troop/monster dispatch to a non-existent target country to avoid undefined index access and unintended side effects.

### Description
- Added an existence check for the target id map before dereferencing ` $hako->idToNumber[$target]` in `trade/hako-turn.php` for the `comSendMonster` case. 
- If the target is missing the code now calls the existing missing-target log `msNoTarget` and cancels the command without applying costs or state changes.
- The change is localized to the `case $init->comSendMonster` branch in `trade/hako-turn.php` and preserves existing log behavior.

### Testing
- Ran `php -l trade/hako-turn.php` which reported no syntax errors for the modified file and succeeded. 
- Ran `git diff --check` which reported no whitespace or diff issues. 
- Attempted a full PHP lint with `find trade -name '*.php' -print0 | xargs -0 -n1 php -l` but it aborted due to a pre-existing parse error in `trade/img/up/sam.php`, unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a816a99605083269ee248c8ece497b9)