### PR TITLE
Log oil field development on wasteland

### DIFF
--- a/trade/hako-turn.php
+++ b/trade/hako-turn.php
@@ -2060,6 +2060,7 @@ class Turn {
 	        if($landKind != $init->landOil) {
 	          $land[$x][$y] = $init->landOil;
 	          $landValue[$x][$y] = 1; // 候補地
+	          $this->log->landSuc($id, $name, $comName, $point);
 	        } else {
 	          $landValue[$x][$y] ++;
 	          if($landValue[$x][$y] > 10){


### PR DESCRIPTION
### Motivation

- Fix missing success log when an oil field development converts a wasteland into an oil-field candidate so the action is reported consistently.

### Description

- Inserted a call to `$this->log->landSuc($id, $name, $comName, $point)` in `trade/hako-turn.php` when `comOild` turns non-oil land into `landOil` (initial conversion).
- Change is a single-line addition in `trade/hako-turn.php` and was committed with message `Log initial oil field development`.

### Testing

- Ran `php -l trade/hako-turn.php` which reported no syntax errors.
- Ran `git diff --check` which reported no whitespace or diff errors.
- Verified `git status --short` shows a clean working tree after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a816c4fe60483269ffbd39a4fdbf1fb)